### PR TITLE
Guarantee safe close - alternate locking strategy

### DIFF
--- a/router/realm.go
+++ b/router/realm.go
@@ -137,8 +137,6 @@ func (r *Realm) SetAuthorizer(authorizer Authorizer) {
 // is only called from the router's single action goroutine, so will never be
 // called by multiple goroutines.
 //
-// Safety guaranteed by the following logic:
-//
 // - Realm guarantees there are never multiple calls to broker.Close() or
 // dealer.Close()
 //
@@ -157,6 +155,10 @@ func (r *Realm) SetAuthorizer(authorizer Authorizer) {
 // meta procedures, there is no metaProcedureHandler() to call Submit(). Any
 // client sessions that are still active likewise have no handleSession() to
 // call Submit() or RemoveSession().
+//
+// TODO: Investigate is it is possible for a new session, starting while realm
+// is closing, to miss its shutdown signal, and make realm wait forever for a
+// session that does not shutdown.
 func (r *Realm) closeRealm() {
 	// The lock is held in mutual exclusion with the router starting any new
 	// session handlers for this realm.  This prevents the router from starting

--- a/router/realm.go
+++ b/router/realm.go
@@ -142,9 +142,9 @@ func (r *Realm) closeRealm() {
 	defer r.dealer.Close()
 
 	// The lock is held in mutual exclusion with the router starting any new
-	// session handlers for this realm.  Therefore, this closing realm prevent
-	// the router from starting any new session handlers and can safely close
-	// after waiting for all existing session handlers to exit.
+	// session handlers for this realm.  This prevents the router from starting
+	// any new session handlers and the realm can safely close after waiting
+	// for all existing session handlers to exit.
 	r.closeLock.Lock()
 	defer r.closeLock.Unlock()
 	r.closed = true

--- a/router/realm.go
+++ b/router/realm.go
@@ -141,6 +141,10 @@ func (r *Realm) closeRealm() {
 	defer r.broker.Close()
 	defer r.dealer.Close()
 
+	// The lock is held in mutual exclusion with the router starting any new
+	// session handlers for this realm.  Therefore, this closing realm prevent
+	// the router from starting any new session handlers and can safely close
+	// after waiting for all existing session handlers to exit.
 	r.closeLock.Lock()
 	defer r.closeLock.Unlock()
 	r.closed = true

--- a/router/realm.go
+++ b/router/realm.go
@@ -158,17 +158,20 @@ func (r *Realm) SetAuthorizer(authorizer Authorizer) {
 // client sessions that are still active likewise have no handleSession() to
 // call Submit() or RemoveSession().
 func (r *Realm) closeRealm() {
+	// The lock is held in mutual exclusion with the router starting any new
+	// session handlers for this realm.  This prevents the router from starting
+	// any new session handlers, allowing the realm can safely close after
+	// waiting for all existing session handlers to exit.
+	r.closeLock.Lock()
+	defer r.closeLock.Unlock()
+	if r.closed {
+		// This realm is already closed.
+		return
+	}
+	r.closed = true
 	// Stop broker and dealer so they can be GC'd, and then so can this realm.
 	defer r.broker.Close()
 	defer r.dealer.Close()
-
-	// The lock is held in mutual exclusion with the router starting any new
-	// session handlers for this realm.  This prevents the router from starting
-	// any new session handlers and the realm can safely close after waiting
-	// for all existing session handlers to exit.
-	r.closeLock.Lock()
-	defer r.closeLock.Unlock()
-	r.closed = true
 
 	r.actionChan <- func() {
 		for _, client := range r.clients {

--- a/router/router.go
+++ b/router/router.go
@@ -271,6 +271,9 @@ func (r *router) Attach(client wamp.Peer) error {
 	details["authmethod"] = welcome.Details["authmethod"]
 	details["authprovider"] = welcome.Details["authprovider"]
 
+	// The lock is held in mutual exclusion with the closing of the realm.
+	// This ensures that no new session handler can start once the realm is
+	// closing and waiting for all existing session handlers to exit.
 	realm.closeLock.Lock()
 	if realm.closed {
 		err := errors.New("realm closed")

--- a/router/router.go
+++ b/router/router.go
@@ -273,7 +273,8 @@ func (r *router) Attach(client wamp.Peer) error {
 
 	// The lock is held in mutual exclusion with the closing of the realm.
 	// This ensures that no new session handler can start once the realm is
-	// closing and waiting for all existing session handlers to exit.
+	// closing, during which the realm waits for all existing session handlers
+	// to exit.
 	realm.closeLock.Lock()
 	if realm.closed {
 		err := errors.New("realm closed")


### PR DESCRIPTION
Closing realm is guaranteed safe by the following, plus changes in this PR:

- Realm guarantees there are never multiple calls to `broker.Close()` or `dealer.Close()`
- `handleSession()` and `metaProcedureHandler()` are the only things than can call broker/dealer.`Submit()` or broker/dealer.`RemoveSession()`
- Closing Realm waits until all `realm.handleSession()` and `realm.metaProcedureHandler()` have exited, thereby guaranteeing that there will be no more `broker/dealer.Submit()` or `broker/dealer.RemoveSession()`, therefore no chance of submitting to closed channel.
- Finally realm closes broker and dealer `reqChan`, which is safe.  Even if broker or dealer are in the process of publishing meta events or calling meta procedures, there is no `metaProcedureHandler()` to call `Submit()`.  Any client sessions that are still active likewise have no `handleSession()` to call `Submit()` or `RemoveSession()`.

The safety exception exception is if the router was attaching a new client and execution got to here (https://github.com/gammazero/nexus/blob/master/router/router.go#L291), but had not yet incremented the counter, and all the close logic had completed just before that, then a new `handleSession()` could be started on a closed realm.

This change prevents the exception by holding a lock while checking if the realm is closed and incrementing the wait counter.  The lock is held in mutual exclusion with the realm closing.