### PR TITLE
Finish fixing realm close synchronization

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -292,6 +292,7 @@ func (r *router) Attach(client wamp.Peer) error {
 	}
 
 	r.waitRealms.Add(1)
+	// Ensure sesson is capable of receiving exit signal before releasing lock.
 	realm.onJoin(sess)
 	realm.closeLock.Unlock()
 


### PR DESCRIPTION
This should fix the final deadlock you identified.  It works by ensuring that the close lock is held until a new session is capable of receiving its shutdown signal (by being added to the realms map).  This way a session cannot be started while realm is closing in such a way that the session would miss its close signal and the realm would wait forever for the  session  to close.