### PR TITLE
Created NewLocalClient and removed LocalClient from router's interface

### DIFF
--- a/aat/main_test.go
+++ b/aat/main_test.go
@@ -92,20 +92,15 @@ func connectClientNoJoin() (*client.Client, error) {
 	if websocketClient {
 		cli, err = client.NewWebsocketClient(
 			serverURL, serialize.JSON, nil, nil, time.Second, cliLogger)
-		if err != nil {
-			cliLogger.Println("Failed to create websocket client:", err)
-			return nil, err
-		}
 	} else {
-		cPeer, sPeer := router.LinkedPeers()
-		go func() {
-			if err := nxr.Attach(sPeer); err != nil {
-				cliLogger.Print("Failed to attach client: ", err)
-			}
-		}()
-
-		cli = client.NewClient(cPeer, 200*time.Millisecond, cliLogger)
+		cli, err = client.NewLocalClient(nxr, 200*time.Millisecond, cliLogger)
 	}
+
+	if err != nil {
+		cliLogger.Println("Failed to create client:", err)
+		return nil, err
+	}
+
 	return cli, nil
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -2,26 +2,13 @@ package client
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/gammazero/nexus/logger"
-	"github.com/gammazero/nexus/transport"
-	"github.com/gammazero/nexus/transport/serialize"
 	"github.com/gammazero/nexus/wamp"
-)
-
-const (
-	// Error URIs returned by this client.
-	errUnexpectedMessageType = "nexus.error.unexpected_message_type"
-	errNoAuthHandler         = "nexus.error.no_handler_for_authmethod"
-	errAuthFailure           = "nexus.error.authentication_failure"
-
-	// Time client will wait for expected router response if not specified.
-	defaultResponseTimeout = 5 * time.Second
 )
 
 var clientRoleFeatures = map[string]interface{}{
@@ -122,19 +109,6 @@ func NewClient(p wamp.Peer, responseTimeout time.Duration, logger logger.Logger)
 	}
 	go c.run()
 	return c
-}
-
-// NewWebsocketClient creates a new websocket client connected to the specified
-// URL and using the specified serialization.
-//
-// JoinRealm must be called before other client functions.
-func NewWebsocketClient(url string, serialization serialize.Serialization, tlscfg *tls.Config, dial transport.DialFunc, responseTimeout time.Duration, logger logger.Logger) (*Client, error) {
-	p, err := transport.ConnectWebsocketPeer(
-		url, serialization, tlscfg, dial, 0, logger)
-	if err != nil {
-		return nil, err
-	}
-	return NewClient(p, responseTimeout, logger), nil
 }
 
 func (c *Client) run() {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gammazero/nexus/auth"
 	"github.com/gammazero/nexus/logger"
 	"github.com/gammazero/nexus/router"
+	"github.com/gammazero/nexus/transport"
 	"github.com/gammazero/nexus/wamp"
 )
 
@@ -31,7 +32,7 @@ func init() {
 }
 
 func getTestPeer(r router.Router) wamp.Peer {
-	cli, rtr := router.LinkedPeers()
+	cli, rtr := transport.LinkedPeers(0, log)
 	go r.Attach(rtr)
 	return cli
 }

--- a/client/const.go
+++ b/client/const.go
@@ -1,0 +1,13 @@
+package client
+
+import "time"
+
+const (
+	// Error URIs returned by this client.
+	errUnexpectedMessageType = "nexus.error.unexpected_message_type"
+	errNoAuthHandler         = "nexus.error.no_handler_for_authmethod"
+	errAuthFailure           = "nexus.error.authentication_failure"
+
+	// Time client will wait for expected router response if not specified.
+	defaultResponseTimeout = 5 * time.Second
+)

--- a/client/local.go
+++ b/client/local.go
@@ -1,0 +1,24 @@
+package client
+
+import (
+	"time"
+
+	"github.com/gammazero/nexus/logger"
+	"github.com/gammazero/nexus/router"
+	"github.com/gammazero/nexus/transport"
+)
+
+// NewLocalClient creates a new client directly connected to embedded router
+//
+// JoinRealm must be called before other client functions.
+func NewLocalClient(router router.Router, responseTimeout time.Duration, logger logger.Logger) (*Client, error) {
+	localSide, routerSide := transport.LinkedPeers(0, logger)
+
+	go func() {
+		if err := router.Attach(routerSide); err != nil {
+			logger.Print(err)
+		}
+	}()
+
+	return NewClient(localSide, responseTimeout, logger), nil
+}

--- a/client/websocket.go
+++ b/client/websocket.go
@@ -1,0 +1,22 @@
+package client
+
+import (
+	"crypto/tls"
+	"time"
+
+	"github.com/gammazero/nexus/logger"
+	"github.com/gammazero/nexus/transport"
+	"github.com/gammazero/nexus/transport/serialize"
+)
+
+// NewWebsocketClient creates a new websocket client connected to the specified
+// URL and using the specified serialization.
+//
+// JoinRealm must be called before other client functions.
+func NewWebsocketClient(url string, serialization serialize.Serialization, tlscfg *tls.Config, dial transport.DialFunc, responseTimeout time.Duration, logger logger.Logger) (*Client, error) {
+	p, err := transport.ConnectWebsocketPeer(url, serialization, tlscfg, dial, 0, logger)
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(p, responseTimeout, logger), nil
+}

--- a/router/dealer.go
+++ b/router/dealer.go
@@ -130,7 +130,7 @@ type dealer struct {
 	metaProcMap map[wamp.ID]func(*wamp.Invocation) wamp.Message
 }
 
-// NewDealer creates a the default Dealer implementation.
+// NewDealer creates the default Dealer implementation.
 func NewDealer(strictURI, allowDisclose bool, metaClient wamp.Peer) Dealer {
 	d := &dealer{
 		procRegMap:    map[wamp.URI]*registration{},

--- a/router/dealer_test.go
+++ b/router/dealer_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gammazero/nexus/transport"
 	"github.com/gammazero/nexus/wamp"
 )
 
 func newTestDealer() (*dealer, wamp.Peer) {
-	metaClient, rtr := LinkedPeers()
+	metaClient, rtr := transport.LinkedPeers(0, log)
 	return NewDealer(false, true, rtr).(*dealer), metaClient
 }
 

--- a/router/realm.go
+++ b/router/realm.go
@@ -204,9 +204,7 @@ func (r *realm) Run() {
 func (r *realm) createMetaSession() (*Session, *Session) {
 	cli, rtr := transport.LinkedPeers(0, log)
 
-	details := map[string]interface{}{
-		"authrole": "trusted",
-	}
+	details := wamp.SetOption(nil, "authrole", "trusted")
 
 	// This session is the local leg of the router uplink.
 	sess := &Session{

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gammazero/nexus/transport"
 	"github.com/gammazero/nexus/wamp"
 )
 
@@ -71,7 +72,7 @@ func handShake(r Router, client, server wamp.Peer) (wamp.ID, error) {
 }
 
 func TestHandshake(t *testing.T) {
-	client, server := LinkedPeers()
+	client, server := transport.LinkedPeers(0, log)
 	r := newTestRouter()
 	defer r.Close()
 	_, err := handShake(r, client, server)
@@ -94,7 +95,7 @@ func TestHandshakeBadRealm(t *testing.T) {
 	r := NewRouter(false, false)
 	defer r.Close()
 
-	client, server := LinkedPeers()
+	client, server := transport.LinkedPeers(0, log)
 
 	client.Send(&wamp.Hello{Realm: "does.not.exist"})
 	err := r.Attach(server)
@@ -116,7 +117,7 @@ func TestHandshakeBadRealm(t *testing.T) {
 func TestRouterSubscribe(t *testing.T) {
 	const testTopic = wamp.URI("some.uri")
 
-	sub, subServer := LinkedPeers()
+	sub, subServer := transport.LinkedPeers(0, log)
 	r := newTestRouter()
 	defer r.Close()
 	_, err := handShake(r, sub, subServer)
@@ -142,7 +143,7 @@ func TestRouterSubscribe(t *testing.T) {
 		subscriptionID = subMsg.Subscription
 	}
 
-	pub, pubServer := LinkedPeers()
+	pub, pubServer := transport.LinkedPeers(0, log)
 	handShake(r, pub, pubServer)
 	pubID := wamp.GlobalID()
 	pub.Send(&wamp.Publish{Request: pubID, Topic: testTopic})
@@ -162,7 +163,7 @@ func TestRouterSubscribe(t *testing.T) {
 }
 
 func TestPublishAcknowledge(t *testing.T) {
-	client, server := LinkedPeers()
+	client, server := transport.LinkedPeers(0, log)
 	r := newTestRouter()
 	defer r.Close()
 	_, err := handShake(r, client, server)
@@ -192,7 +193,7 @@ func TestPublishAcknowledge(t *testing.T) {
 }
 
 func TestPublishFalseAcknowledge(t *testing.T) {
-	client, server := LinkedPeers()
+	client, server := transport.LinkedPeers(0, log)
 	r := newTestRouter()
 	defer r.Close()
 	_, err := handShake(r, client, server)
@@ -217,7 +218,7 @@ func TestPublishFalseAcknowledge(t *testing.T) {
 }
 
 func TestPublishNoAcknowledge(t *testing.T) {
-	client, server := LinkedPeers()
+	client, server := transport.LinkedPeers(0, log)
 	r := newTestRouter()
 	defer r.Close()
 	_, err := handShake(r, client, server)
@@ -238,7 +239,7 @@ func TestPublishNoAcknowledge(t *testing.T) {
 }
 
 func TestRouterCall(t *testing.T) {
-	callee, calleeServer := LinkedPeers()
+	callee, calleeServer := transport.LinkedPeers(0, log)
 	r := newTestRouter()
 	defer r.Close()
 	_, err := handShake(r, callee, calleeServer)
@@ -265,7 +266,7 @@ func TestRouterCall(t *testing.T) {
 		registrationID = registered.Registration
 	}
 
-	caller, callerServer := LinkedPeers()
+	caller, callerServer := transport.LinkedPeers(0, log)
 	caller.Send(&wamp.Hello{Realm: testRealm, Details: clientRoles})
 	if err := r.Attach(callerServer); err != nil {
 		t.Fatal("Error connecting caller:", err)
@@ -313,7 +314,7 @@ func TestSessionMetaProcedures(t *testing.T) {
 	r := newTestRouter()
 	defer r.Close()
 
-	caller, callerServer := LinkedPeers()
+	caller, callerServer := transport.LinkedPeers(0, log)
 	sessID, err := handShake(r, caller, callerServer)
 	if err != nil {
 		t.Fatal(err)
@@ -432,7 +433,7 @@ func TestRegistrationMetaProcedures(t *testing.T) {
 	r := newTestRouter()
 	defer r.Close()
 
-	caller, callerServer := LinkedPeers()
+	caller, callerServer := transport.LinkedPeers(0, log)
 	sessID, err := handShake(r, caller, callerServer)
 	if err != nil {
 		t.Fatal(err)
@@ -475,7 +476,7 @@ func TestRegistrationMetaProcedures(t *testing.T) {
 		t.Fatal("expected []wamp.ID")
 	}
 
-	callee, calleeServer := LinkedPeers()
+	callee, calleeServer := transport.LinkedPeers(0, log)
 	sessID, err = handShake(r, callee, calleeServer)
 	if err != nil {
 		t.Fatal(err)

--- a/router/session.go
+++ b/router/session.go
@@ -6,8 +6,6 @@ import (
 	"github.com/gammazero/nexus/wamp"
 )
 
-const peerChanSize = 16
-
 // Session is an active WAMP session.
 type Session struct {
 	wamp.Peer
@@ -45,59 +43,3 @@ func CheckFeature(role, feature string, sessions ...Session) bool {
 	}
 	return true
 }
-
-// LinkedPeers creates two connected peers.  Messages sent to one peer
-// appear in the Recv of the other.
-//
-// This is used for connecting client sessions to the router.
-//
-// Exported since it is used in test code for creating in-process test clients.
-func LinkedPeers() (*localPeer, *localPeer) {
-	// The channel used for the router to send messages to the client should be
-	// large enough to prevent blocking while waiting for a slow client, as a
-	// client may block on I/O.  If the client does block, then the message
-	// should be dropped.
-	rToC := make(chan wamp.Message, 16)
-
-	// Messages read from a client can usually be handled immediately, since
-	// routing is fast and does not block on I/O.  Therefore this channle does
-	// not need to be more than size 1.
-	cToR := make(chan wamp.Message, 1)
-
-	// router reads from and writes to client
-	r := &localPeer{rd: cToR, wr: rToC, wrRtoC: true}
-	// client reads from and writes to router
-	c := &localPeer{rd: rToC, wr: cToR}
-
-	return c, r
-}
-
-// localPeer implements Peer
-type localPeer struct {
-	wr     chan<- wamp.Message
-	rd     <-chan wamp.Message
-	wrRtoC bool
-}
-
-// Recv returns the channel this peer reads incoming messages from.
-func (p *localPeer) Recv() <-chan wamp.Message { return p.rd }
-
-// Send write a message to the channel the peer sends outgoing messages to.
-func (p *localPeer) Send(msg wamp.Message) {
-	if p.wrRtoC {
-		select {
-		case p.wr <- msg:
-		default:
-			fmt.Println("WARNING: client blocked router.  Dropped:",
-				msg.MessageType())
-		}
-		return
-	}
-	// It is OK for the router to block a client since this will not block
-	// other clients.
-	p.wr <- msg
-}
-
-// Close closes the outgoing channel, waking any readers waiting on data from
-// this peer.
-func (p *localPeer) Close() { close(p.wr) }

--- a/transport/localpeer.go
+++ b/transport/localpeer.go
@@ -1,0 +1,69 @@
+package transport
+
+import (
+	"github.com/gammazero/nexus/logger"
+	"github.com/gammazero/nexus/wamp"
+)
+
+const defaultLinkedPeersOutQueueSize = 16
+
+// LinkedPeers creates two connected peers.  Messages sent to one peer
+// appear in the Recv of the other.
+//
+// This is used for connecting client sessions to the router.
+//
+// Exported since it is used in test code for creating in-process test clients.
+func LinkedPeers(outQueueSize int, logger logger.Logger) (wamp.Peer, wamp.Peer) {
+	if outQueueSize < 1 {
+		outQueueSize = defaultLinkedPeersOutQueueSize
+	}
+
+	// The channel used for the router to send messages to the client should be
+	// large enough to prevent blocking while waiting for a slow client, as a
+	// client may block on I/O.  If the client does block, then the message
+	// should be dropped.
+	rToC := make(chan wamp.Message, outQueueSize)
+
+	// Messages read from a client can usually be handled immediately, since
+	// routing is fast and does not block on I/O.  Therefore this channle does
+	// not need to be more than size 1.
+	cToR := make(chan wamp.Message, 1)
+
+	// router reads from and writes to client
+	r := &localPeer{rd: cToR, wr: rToC, wrRtoC: true}
+	// client reads from and writes to router
+	c := &localPeer{rd: rToC, wr: cToR}
+
+	return c, r
+}
+
+// localPeer implements Peer
+type localPeer struct {
+	wr     chan<- wamp.Message
+	rd     <-chan wamp.Message
+	wrRtoC bool
+	log    logger.Logger
+}
+
+// Recv returns the channel this peer reads incoming messages from.
+func (p *localPeer) Recv() <-chan wamp.Message { return p.rd }
+
+// Send write a message to the channel the peer sends outgoing messages to.
+func (p *localPeer) Send(msg wamp.Message) {
+	if p.wrRtoC {
+		select {
+		case p.wr <- msg:
+		default:
+			p.log.Println("WARNING: client blocked router.  Dropped:",
+				msg.MessageType())
+		}
+		return
+	}
+	// It is OK for the router to block a client since this will not block
+	// other clients.
+	p.wr <- msg
+}
+
+// Close closes the outgoing channel, waking any readers waiting on data from
+// this peer.
+func (p *localPeer) Close() { close(p.wr) }


### PR DESCRIPTION
This PR moves the LocalClient from the router's interface to `client` package. It also moves the `LinkedPeers` from `router/session.go` to `transport/localpeer.go` (following the same pattern as `transport/websocketpeer.go`)