### PR TITLE
Channelsizing

### DIFF
--- a/aat/rpcshared_test.go
+++ b/aat/rpcshared_test.go
@@ -1,0 +1,224 @@
+package aat
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gammazero/nexus/client"
+	"github.com/gammazero/nexus/wamp"
+)
+
+func TestRPCSharedRoundRobin(t *testing.T) {
+	const procName = "shared.test.procedure"
+	options := wamp.SetOption(nil, "invoke", "roundrobin")
+
+	// Connect callee1 and register test procedure.
+	callee1, err := connectClient()
+	if err != nil {
+		t.Fatal("Failed to connect client: ", err)
+	}
+	testProc1 := func(ctx context.Context, args []interface{}, kwargs, details map[string]interface{}) *client.InvokeResult {
+		return &client.InvokeResult{Args: []interface{}{1}}
+	}
+	if err = callee1.Register(procName, testProc1, options); err != nil {
+		t.Fatal("failed to register procedure: ", err)
+	}
+
+	// Connect callee2 and register test procedure.
+	callee2, err := connectClient()
+	if err != nil {
+		t.Fatal("Failed to connect client: ", err)
+	}
+	testProc2 := func(ctx context.Context, args []interface{}, kwargs, details map[string]interface{}) *client.InvokeResult {
+		return &client.InvokeResult{Args: []interface{}{2}}
+	}
+	if err = callee2.Register(procName, testProc2, options); err != nil {
+		t.Fatal("failed to register procedure: ", err)
+	}
+
+	// Connect callee3 and register test procedure.
+	callee3, err := connectClient()
+	if err != nil {
+		t.Fatal("Failed to connect client: ", err)
+	}
+	testProc3 := func(ctx context.Context, args []interface{}, kwargs, details map[string]interface{}) *client.InvokeResult {
+		return &client.InvokeResult{Args: []interface{}{3}}
+	}
+	if err = callee3.Register(procName, testProc3, options); err != nil {
+		t.Fatal("failed to register procedure: ", err)
+	}
+
+	// Connect caller session.
+	caller, err := connectClient()
+	if err != nil {
+		t.Fatal("Failed to connect client: ", err)
+	}
+
+	expect := int64(1)
+	for i := 0; i < 5; i++ {
+		// Test calling the procedure - expect callee1-3
+		ctx := context.Background()
+		result, err := caller.Call(ctx, procName, options, nil, nil, "")
+		if err != nil {
+			t.Fatal("failed to call procedure: ", err)
+		}
+		num, _ := wamp.AsInt64(result.Arguments[0])
+		if num != expect {
+			t.Fatal("got result from wrong callee")
+		}
+		if expect == 3 {
+			expect = 1
+		} else {
+			expect++
+		}
+	}
+
+	// Unregister callee2 and make sure round robin still works.
+	if err = callee2.Unregister(procName); err != nil {
+		t.Fatal("failed to unregister procedure: ", err)
+	}
+
+	expect = int64(1)
+	for i := 0; i < 5; i++ {
+		// Test calling the procedure - expect callee1-3
+		ctx := context.Background()
+		result, err := caller.Call(ctx, procName, options, nil, nil, "")
+		if err != nil {
+			t.Fatal("failed to call procedure: ", err)
+		}
+		num, _ := wamp.AsInt64(result.Arguments[0])
+		if num != expect {
+			t.Fatal("got result from wrong callee")
+		}
+		if expect == 1 {
+			expect = 3
+		} else {
+			expect = 1
+		}
+	}
+
+	// Test unregister.
+	if err = callee1.Unregister(procName); err != nil {
+		t.Fatal("failed to unregister procedure: ", err)
+	}
+	if err = callee3.Unregister(procName); err != nil {
+		t.Fatal("failed to unregister procedure: ", err)
+	}
+
+	err = callee1.Close()
+	if err != nil {
+		t.Fatal("Failed to disconnect client: ", err)
+	}
+	err = callee2.Close()
+	if err != nil {
+		t.Fatal("Failed to disconnect client: ", err)
+	}
+	err = callee3.Close()
+	if err != nil {
+		t.Fatal("Failed to disconnect client: ", err)
+	}
+
+	err = caller.Close()
+	if err != nil {
+		t.Fatal("Failed to disconnect client: ", err)
+	}
+}
+
+func TestRPCSharedRandom(t *testing.T) {
+	const procName = "shared.test.procedure"
+	options := wamp.SetOption(nil, "invoke", "random")
+
+	// Connect callee1 and register test procedure.
+	callee1, err := connectClient()
+	if err != nil {
+		t.Fatal("Failed to connect client: ", err)
+	}
+	testProc1 := func(ctx context.Context, args []interface{}, kwargs, details map[string]interface{}) *client.InvokeResult {
+		return &client.InvokeResult{Args: []interface{}{1}}
+	}
+	if err = callee1.Register(procName, testProc1, options); err != nil {
+		t.Fatal("failed to register procedure: ", err)
+	}
+
+	// Connect callee2 and register test procedure.
+	callee2, err := connectClient()
+	if err != nil {
+		t.Fatal("Failed to connect client: ", err)
+	}
+	testProc2 := func(ctx context.Context, args []interface{}, kwargs, details map[string]interface{}) *client.InvokeResult {
+		return &client.InvokeResult{Args: []interface{}{2}}
+	}
+	if err = callee2.Register(procName, testProc2, options); err != nil {
+		t.Fatal("failed to register procedure: ", err)
+	}
+
+	// Connect callee3 and register test procedure.
+	callee3, err := connectClient()
+	if err != nil {
+		t.Fatal("Failed to connect client: ", err)
+	}
+	testProc3 := func(ctx context.Context, args []interface{}, kwargs, details map[string]interface{}) *client.InvokeResult {
+		return &client.InvokeResult{Args: []interface{}{3}}
+	}
+	if err = callee3.Register(procName, testProc3, options); err != nil {
+		t.Fatal("failed to register procedure: ", err)
+	}
+
+	// Connect caller session.
+	caller, err := connectClient()
+	if err != nil {
+		t.Fatal("Failed to connect client: ", err)
+	}
+
+	var called1, called2, called3 int
+	var i int
+	for i = 0; i < 20; i++ {
+		// Test calling the procedure - expect callee1-3
+		ctx := context.Background()
+		result, err := caller.Call(ctx, procName, options, nil, nil, "")
+		if err != nil {
+			t.Fatal("failed to call procedure: ", err)
+		}
+		num, _ := wamp.AsInt64(result.Arguments[0])
+		switch num {
+		case 1:
+			called1++
+		case 2:
+			called2++
+		case 3:
+			called3++
+		}
+	}
+	if called1 == i || called2 == i || called3 == i {
+		t.Error("only called one callee with random distribution")
+	}
+
+	// Test unregister.
+	if err = callee1.Unregister(procName); err != nil {
+		t.Fatal("failed to unregister procedure: ", err)
+	}
+	if err = callee2.Unregister(procName); err != nil {
+		t.Fatal("failed to unregister procedure: ", err)
+	}
+	if err = callee3.Unregister(procName); err != nil {
+		t.Fatal("failed to unregister procedure: ", err)
+	}
+
+	err = callee1.Close()
+	if err != nil {
+		t.Fatal("Failed to disconnect client: ", err)
+	}
+	err = callee2.Close()
+	if err != nil {
+		t.Fatal("Failed to disconnect client: ", err)
+	}
+	err = callee3.Close()
+	if err != nil {
+		t.Fatal("Failed to disconnect client: ", err)
+	}
+
+	err = caller.Close()
+	if err != nil {
+		t.Fatal("Failed to disconnect client: ", err)
+	}
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -27,7 +27,7 @@ func init() {
 }
 
 func getTestPeer(r router.Router) wamp.Peer {
-	cli, rtr := transport.LinkedPeers(0, log)
+	cli, rtr := transport.LinkedPeers(log)
 	go r.Attach(rtr)
 	return cli
 }

--- a/client/local.go
+++ b/client/local.go
@@ -12,7 +12,7 @@ import (
 //
 // JoinRealm must be called before other client functions.
 func NewLocalClient(router router.Router, responseTimeout time.Duration, logger logger.Logger) (*Client, error) {
-	localSide, routerSide := transport.LinkedPeers(0, logger)
+	localSide, routerSide := transport.LinkedPeers(logger)
 
 	go func() {
 		if err := router.Attach(routerSide); err != nil {

--- a/client/websocket.go
+++ b/client/websocket.go
@@ -14,7 +14,7 @@ import (
 //
 // JoinRealm must be called before other client functions.
 func NewWebsocketClient(url string, serialization serialize.Serialization, tlscfg *tls.Config, dial transport.DialFunc, responseTimeout time.Duration, logger logger.Logger) (*Client, error) {
-	p, err := transport.ConnectWebsocketPeer(url, serialization, tlscfg, dial, 0, logger)
+	p, err := transport.ConnectWebsocketPeer(url, serialization, tlscfg, dial, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/router/broker.go
+++ b/router/broker.go
@@ -83,11 +83,10 @@ func NewBroker(strictURI, allowDisclose bool) Broker {
 
 		sessionSubIDSet: map[*Session]map[wamp.ID]struct{}{},
 
-		// The request handler channel does not need to be more than size one,
-		// since the incoming messages will be processed at the same rate
-		// whether the messages sit in the recv channel of peers, or they sit
-		// in the reqChan.
-		reqChan: make(chan brokerReq, 1),
+		// The request handler should be nearly always runable, since it is
+		// the critical section that does the only routing. So, and unbuffered
+		// channel is appropriate.
+		reqChan: make(chan brokerReq),
 
 		idGen: wamp.NewIDGen(),
 

--- a/router/dealer.go
+++ b/router/dealer.go
@@ -144,11 +144,10 @@ func NewDealer(strictURI, allowDisclose bool, metaClient wamp.Peer) Dealer {
 		invocationByCall: map[wamp.ID]wamp.ID{},
 		calleeRegIDSet:   map[*Session]map[wamp.ID]struct{}{},
 
-		// The request handler channel does not need to be more than size one,
-		// since the incoming messages will be processed at the same rate
-		// whether the messages sit in the recv channel of peers, or they sit
-		// in the reqChan.
-		reqChan: make(chan dealerReq, 1),
+		// The request handler should be nearly always runable, since it is
+		// the critical section that does the only routing. So, and unbuffered
+		// channel is appropriate.
+		reqChan: make(chan dealerReq),
 
 		idGen: wamp.NewIDGen(),
 		prng:  rand.New(rand.NewSource(time.Now().Unix())),

--- a/router/dealer_test.go
+++ b/router/dealer_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func newTestDealer() (*dealer, wamp.Peer) {
-	metaClient, rtr := transport.LinkedPeers(0, log)
+	metaClient, rtr := transport.LinkedPeers(log)
 	return NewDealer(false, true, rtr).(*dealer), metaClient
 }
 

--- a/router/realm.go
+++ b/router/realm.go
@@ -194,7 +194,7 @@ func (r *realm) run() {
 //
 // This is used for creating a local client for publishing meta events.
 func (r *realm) createMetaSession() (*Session, *Session) {
-	cli, rtr := transport.LinkedPeers(0, log)
+	cli, rtr := transport.LinkedPeers(log)
 
 	details := wamp.SetOption(nil, "authrole", "trusted")
 

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -127,7 +127,10 @@ func TestHandshakeBadRealm(t *testing.T) {
 
 func TestRouterSubscribe(t *testing.T) {
 	const testTopic = wamp.URI("some.uri")
-	r, _ := newTestRouter()
+	r, err := newTestRouter()
+	if err != nil {
+		t.Error(err)
+	}
 	defer r.Close()
 
 	sub, err := testClient(r)
@@ -175,7 +178,10 @@ func TestRouterSubscribe(t *testing.T) {
 }
 
 func TestPublishAcknowledge(t *testing.T) {
-	r, _ := newTestRouter()
+	r, err := newTestRouter()
+	if err != nil {
+		t.Error(err)
+	}
 	defer r.Close()
 	client, err := testClient(r)
 	if err != nil {
@@ -204,7 +210,10 @@ func TestPublishAcknowledge(t *testing.T) {
 }
 
 func TestPublishFalseAcknowledge(t *testing.T) {
-	r, _ := newTestRouter()
+	r, err := newTestRouter()
+	if err != nil {
+		t.Error(err)
+	}
 	defer r.Close()
 	client, err := testClient(r)
 	if err != nil {
@@ -228,7 +237,10 @@ func TestPublishFalseAcknowledge(t *testing.T) {
 }
 
 func TestPublishNoAcknowledge(t *testing.T) {
-	r, _ := newTestRouter()
+	r, err := newTestRouter()
+	if err != nil {
+		t.Error(err)
+	}
 	defer r.Close()
 	client, err := testClient(r)
 	if err != nil {
@@ -248,7 +260,10 @@ func TestPublishNoAcknowledge(t *testing.T) {
 }
 
 func TestRouterCall(t *testing.T) {
-	r, _ := newTestRouter()
+	r, err := newTestRouter()
+	if err != nil {
+		t.Error(err)
+	}
 	defer r.Close()
 	callee, err := testClient(r)
 	if err != nil {
@@ -315,7 +330,10 @@ func TestRouterCall(t *testing.T) {
 }
 
 func TestSessionMetaProcedures(t *testing.T) {
-	r, _ := newTestRouter()
+	r, err := newTestRouter()
+	if err != nil {
+		t.Error(err)
+	}
 	defer r.Close()
 
 	caller, err := testClient(r)
@@ -434,7 +452,10 @@ func TestSessionMetaProcedures(t *testing.T) {
 }
 
 func TestRegistrationMetaProcedures(t *testing.T) {
-	r, _ := newTestRouter()
+	r, err := newTestRouter()
+	if err != nil {
+		t.Error(err)
+	}
 	defer r.Close()
 
 	caller, err := testClient(r)

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -111,8 +111,8 @@ func TestHandshakeBadRealm(t *testing.T) {
 	client, server := transport.LinkedPeers(log)
 	go client.Send(&wamp.Hello{Realm: "does.not.exist"})
 	err = r.Attach(server)
-	if err != nil {
-		t.Fatal(err)
+	if err == nil {
+		t.Fatal("expected error")
 	}
 
 	select {

--- a/server/websocketserver.go
+++ b/server/websocketserver.go
@@ -105,7 +105,7 @@ func (s *WebsocketServer) handleWebsocket(conn *websocket.Conn) {
 
 	// Create a websocket peer from the websocket connection and attach the
 	// peer to the router.
-	peer := transport.NewWebsocketPeer(conn, serializer, payloadType, 16, log)
+	peer := transport.NewWebsocketPeer(conn, serializer, payloadType, log)
 	if err := s.Router.Attach(peer); err != nil {
 		log.Println(err)
 	}

--- a/server/websocketserver_test.go
+++ b/server/websocketserver_test.go
@@ -70,7 +70,7 @@ func TestWSHandshakeJSON(t *testing.T) {
 	defer closer.Close()
 
 	client, err := transport.ConnectWebsocketPeer(
-		fmt.Sprintf("ws://localhost:%d/", port), serialize.JSON, nil, nil, 0, router.Logger())
+		fmt.Sprintf("ws://localhost:%d/", port), serialize.JSON, nil, nil, router.Logger())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +93,7 @@ func TestWSHandshakeMsgpack(t *testing.T) {
 	defer closer.Close()
 
 	client, err := transport.ConnectWebsocketPeer(
-		fmt.Sprintf("ws://localhost:%d/", port), serialize.MSGPACK, nil, nil, 0, router.Logger())
+		fmt.Sprintf("ws://localhost:%d/", port), serialize.MSGPACK, nil, nil, router.Logger())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/transport/websocketpeer.go
+++ b/transport/websocketpeer.go
@@ -39,8 +39,8 @@ const (
 	jsonWebsocketProtocol    = "wamp.2.json"
 	msgpackWebsocketProtocol = "wamp.2.msgpack"
 
-	defaultOutQueueSize = 16
-	ctrlTimeout         = 5 * time.Second
+	outQueueSize = 16
+	ctrlTimeout  = 5 * time.Second
 )
 
 type DialFunc func(network, addr string) (net.Conn, error)
@@ -52,7 +52,7 @@ type DialFunc func(network, addr string) (net.Conn, error)
 // to the websocker.  Once the queue has reached this limit, the WAMP router
 // will drop messages in order to not block.  A value of < 1 uses the default
 // size.
-func ConnectWebsocketPeer(url string, serialization serialize.Serialization, tlsConfig *tls.Config, dial DialFunc, outQueueSize int, logger logger.Logger) (wamp.Peer, error) {
+func ConnectWebsocketPeer(url string, serialization serialize.Serialization, tlsConfig *tls.Config, dial DialFunc, logger logger.Logger) (wamp.Peer, error) {
 	var (
 		protocol    string
 		payloadType int
@@ -82,16 +82,13 @@ func ConnectWebsocketPeer(url string, serialization serialize.Serialization, tls
 	if err != nil {
 		return nil, err
 	}
-	return NewWebsocketPeer(conn, serializer, payloadType, outQueueSize, logger), nil
+	return NewWebsocketPeer(conn, serializer, payloadType, logger), nil
 }
 
 // NewWebsockerPeer creates a websocket peer from an existing websocket
 // connection.  This is used for for hanndling clients connecting to the WAMP
 // service.
-func NewWebsocketPeer(conn *websocket.Conn, serializer serialize.Serializer, payloadType int, outQueueSize int, logger logger.Logger) wamp.Peer {
-	if outQueueSize < 1 {
-		outQueueSize = defaultOutQueueSize
-	}
+func NewWebsocketPeer(conn *websocket.Conn, serializer serialize.Serializer, payloadType int, logger logger.Logger) wamp.Peer {
 	w := &websocketPeer{
 		conn:         conn,
 		serializer:   serializer,


### PR DESCRIPTION
This is a smaller PR in prep for some more changes to broker/dealer to move work of critical routing goroutine.

The outQueue size is no longer configurable as the size should be a small fixed size only needed in the case that kernel buffers are filled up temporarily and a send to the client blocks.  It is not helpful for the user to try to provide a guess for the best size.