### PR TITLE
Implementation to filter by org_id using client filter tool

### DIFF
--- a/aat/sessionfilter_test.go
+++ b/aat/sessionfilter_test.go
@@ -1,0 +1,98 @@
+package aat
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gammazero/nexus/extras/filtertool"
+	"github.com/gammazero/nexus/wamp"
+)
+
+func TestFilter(t *testing.T) {
+	// Setup subscriber1
+	subscriber1, err := connectClientDetails(wamp.Dict{"org_id": "spirent"})
+	if err != nil {
+		t.Fatal("Failed to connect client:", err)
+	}
+	sync1 := make(chan struct{})
+	evtHandler1 := func(args wamp.List, kwargs wamp.Dict, details wamp.Dict) {
+		sync1 <- struct{}{}
+	}
+	err = subscriber1.Subscribe(testTopic, evtHandler1, nil)
+	if err != nil {
+		t.Fatal("subscribe error:", err)
+	}
+
+	// Setup subscriber2
+	subscriber2, err := connectClientDetails(wamp.Dict{"org_id": "other"})
+	if err != nil {
+		t.Fatal("Failed to connect client:", err)
+	}
+	sync2 := make(chan struct{})
+	evtHandler2 := func(args wamp.List, kwargs wamp.Dict, details wamp.Dict) {
+		sync1 <- struct{}{}
+	}
+	err = subscriber2.Subscribe(testTopic, evtHandler2, nil)
+	if err != nil {
+		t.Fatal("subscribe error:", err)
+	}
+
+	// Create filter tool to maintain whitelist.
+	filter := func(d wamp.Dict) bool {
+		if org_id, ok := d["org_id"]; ok {
+			if org_id == "spirent" {
+				cliLogger.Println("---> allow session:", d["session"])
+				return true
+			}
+		}
+		cliLogger.Println("---> deny session:", d["session"])
+		return false
+	}
+
+	// Connect publisher
+	publisher, err := connectClient()
+	if err != nil {
+		t.Fatal("Failed to connect client:", err)
+	}
+
+	ft, err := filtertool.New(publisher, filter)
+	if err != nil {
+		t.Fatal("Failed to create filter tool:", err)
+	}
+
+	wl := ft.UpdateWhiteList(nil)
+	opts := wamp.Dict{"eligible": wl}
+	fmt.Println("---> whitelist:", wl)
+	// Publish an event to something that matches by wildcard.
+	publisher.Publish(testTopic, opts, wamp.List{"hello world"}, nil)
+
+	// Make sure the event was received by subscriber1
+	select {
+	case <-sync1:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Subscriber1 did not get published event")
+	}
+
+	// Make sure the event was not received by subscriber2
+	select {
+	case <-sync2:
+		t.Fatal("Subscriber2 received published event")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	ft.Close()
+	err = publisher.Close()
+	if err != nil {
+		t.Fatal("Failed to disconnect client:", err)
+	}
+
+	err = subscriber1.Close()
+	if err != nil {
+		t.Fatal("Failed to disconnect client:", err)
+	}
+	err = subscriber2.Close()
+	if err != nil {
+		t.Fatal("Failed to disconnect client:", err)
+	}
+}

--- a/extras/filtertool/filtertool.go
+++ b/extras/filtertool/filtertool.go
@@ -1,0 +1,188 @@
+package filtertool
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gammazero/nexus/client"
+	"github.com/gammazero/nexus/wamp"
+)
+
+type FilterFunc func(sessDetails wamp.Dict) (allowed bool)
+
+type FilterTool struct {
+	monitor     *client.Client
+	newSessChan chan wamp.Dict
+	delSessChan chan wamp.ID
+	reqWLChan   chan bool
+	rspWLChan   chan []wamp.ID
+	closeChan   chan struct{}
+	doneChan    chan struct{}
+	filter      FilterFunc
+	whiteList   map[wamp.ID]struct{}
+	wlStale     bool
+}
+
+const (
+	metaOnJoin  = string(wamp.MetaEventSessionOnJoin)
+	metaOnLeave = string(wamp.MetaEventSessionOnLeave)
+	metaList    = string(wamp.MetaProcSessionList)
+	metaGet     = string(wamp.MetaProcSessionGet)
+)
+
+func New(monitor *client.Client, filter FilterFunc) (*FilterTool, error) {
+	f := &FilterTool{
+		monitor:     monitor,
+		newSessChan: make(chan wamp.Dict, 1),
+		delSessChan: make(chan wamp.ID, 1),
+		reqWLChan:   make(chan bool),
+		rspWLChan:   make(chan []wamp.ID),
+		closeChan:   make(chan struct{}),
+		doneChan:    make(chan struct{}),
+		filter:      filter,
+		whiteList:   map[wamp.ID]struct{}{},
+		wlStale:     true,
+	}
+	errChan := make(chan error)
+	go f.updateHandler(errChan)
+	err := <-errChan
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+func (f *FilterTool) UpdateWhiteList(wl []wamp.ID) []wamp.ID {
+	var force bool
+	if wl == nil {
+		f.reqWLChan <- force
+		return <-f.rspWLChan
+	}
+	upWL := <-f.rspWLChan
+	if upWL == nil {
+		return wl
+	}
+	return upWL
+}
+
+func (f *FilterTool) Close() {
+	close(f.closeChan)
+	<-f.doneChan
+}
+
+func (f *FilterTool) updateHandler(errChan chan error) {
+	defer close(f.doneChan)
+
+	// Publisher subscribes to on_join and on_leave events.
+	leaveHandler := func(args wamp.List, kwargs wamp.Dict, details wamp.Dict) {
+		if len(args) == 0 {
+			return
+		}
+		if sid, ok := wamp.AsID(args[0]); ok {
+			f.delSessChan <- sid
+		}
+	}
+	joinHandler := func(args wamp.List, kwargs wamp.Dict, details wamp.Dict) {
+		if len(args) == 0 {
+			return
+		}
+		if d, ok := wamp.AsDict(args[0]); ok {
+			f.newSessChan <- d
+		}
+	}
+	err := f.monitor.Subscribe(metaOnJoin, joinHandler, nil)
+	if err != nil {
+		errChan <- fmt.Errorf("subscribe error: %s", err)
+		return
+	}
+	defer f.monitor.Unsubscribe(metaOnJoin)
+	if err = f.monitor.Subscribe(metaOnLeave, leaveHandler, nil); err != nil {
+		errChan <- fmt.Errorf("subscribe error: %s", err)
+		return
+	}
+	defer f.monitor.Unsubscribe(metaOnLeave)
+
+	if err = f.getCurrentSessionInfo(); err != nil {
+		errChan <- fmt.Errorf("failed to get session info: %s", err)
+		return
+	}
+
+	errChan <- nil
+
+	for {
+		select {
+		case d := <-f.newSessChan:
+			f.addSession(d)
+		case s := <-f.delSessChan:
+			f.delSession(s)
+		case force := <-f.reqWLChan:
+			var wl []wamp.ID
+			if force || f.wlStale {
+				wl = make([]wamp.ID, len(f.whiteList))
+				var i int
+				for sid := range f.whiteList {
+					wl[i] = sid
+					i++
+				}
+			}
+			f.rspWLChan <- wl
+		case <-f.closeChan:
+			return
+		}
+	}
+}
+
+func (f *FilterTool) addSession(d wamp.Dict) {
+	sid, ok := wamp.AsID(d["session"])
+	if !ok {
+		return
+	}
+	if f.filter(d) {
+		f.whiteList[sid] = struct{}{}
+	}
+}
+
+func (f *FilterTool) delSession(s wamp.ID) {
+	delete(f.whiteList, s)
+}
+
+func (f *FilterTool) getCurrentSessionInfo() error {
+	ctx := context.Background()
+	result, err := f.monitor.Call(ctx, metaList, nil, nil, nil, "")
+	if err != nil {
+		return err
+	}
+	if len(result.Arguments) == 0 {
+		return nil
+	}
+	list, ok := wamp.AsList(result.Arguments[0])
+	if !ok {
+		return errors.New("could not convert result to wamp.List")
+	}
+	for i := range list {
+		// Call meta procedure to get session info.
+		sid, ok := wamp.AsID(list[i])
+		if !ok {
+			continue
+		}
+		result, err = f.monitor.Call(ctx, metaGet, nil, wamp.List{sid}, nil, "")
+		if err != nil {
+			if rpcErr, ok := err.(client.RPCError); ok {
+				if rpcErr.Err.Error == wamp.ErrNoSuchSession {
+					continue
+				}
+			}
+			return err
+		}
+		if len(result.Arguments) == 0 {
+			continue
+		}
+		dict, ok := wamp.AsDict(result.Arguments[0])
+		if !ok {
+			return errors.New("could not convert result to wamp.Dict")
+		}
+		f.addSession(dict)
+	}
+	return nil
+}


### PR DESCRIPTION
*DO NOT MERGE*

This is to demonstrate filtering by org_id by having client examine session details to maintain whitelist of session IDs.

NOTE: Changes to session meta in `realm.go` may not comply with WAMP spec. 