### PR TITLE
Blackwhitelist

### DIFF
--- a/aat/sessionfilter_test.go
+++ b/aat/sessionfilter_test.go
@@ -29,7 +29,7 @@ func TestWhitelistAttribute(t *testing.T) {
 	}
 	sync2 := make(chan struct{})
 	evtHandler2 := func(args wamp.List, kwargs wamp.Dict, details wamp.Dict) {
-		sync1 <- struct{}{}
+		sync2 <- struct{}{}
 	}
 	err = subscriber2.Subscribe(testTopic, evtHandler2, nil)
 	if err != nil {
@@ -93,7 +93,7 @@ func TestBlacklistAttribute(t *testing.T) {
 	}
 	sync2 := make(chan struct{})
 	evtHandler2 := func(args wamp.List, kwargs wamp.Dict, details wamp.Dict) {
-		sync1 <- struct{}{}
+		sync2 <- struct{}{}
 	}
 	err = subscriber2.Subscribe(testTopic, evtHandler2, nil)
 	if err != nil {

--- a/aat/sessionfilter_test.go
+++ b/aat/sessionfilter_test.go
@@ -1,0 +1,136 @@
+package aat
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gammazero/nexus/wamp"
+)
+
+func TestWhitelistAttribute(t *testing.T) {
+	// Setup subscriber1
+	subscriber1, err := connectClientDetails(wamp.Dict{"org_id": "spirent"})
+	if err != nil {
+		t.Fatal("Failed to connect client:", err)
+	}
+	sync1 := make(chan struct{})
+	evtHandler1 := func(args wamp.List, kwargs wamp.Dict, details wamp.Dict) {
+		sync1 <- struct{}{}
+	}
+	err = subscriber1.Subscribe(testTopic, evtHandler1, nil)
+	if err != nil {
+		t.Fatal("subscribe error:", err)
+	}
+
+	// Setup subscriber2
+	subscriber2, err := connectClientDetails(wamp.Dict{"org_id": "other"})
+	if err != nil {
+		t.Fatal("Failed to connect client:", err)
+	}
+	sync2 := make(chan struct{})
+	evtHandler2 := func(args wamp.List, kwargs wamp.Dict, details wamp.Dict) {
+		sync1 <- struct{}{}
+	}
+	err = subscriber2.Subscribe(testTopic, evtHandler2, nil)
+	if err != nil {
+		t.Fatal("subscribe error:", err)
+	}
+
+	// Connect publisher
+	publisher, err := connectClient()
+	if err != nil {
+		t.Fatal("Failed to connect client:", err)
+	}
+
+	opts := wamp.Dict{"eligible_org_id": wamp.List{"spirent", "goodguys"}}
+
+	// Publish an event to something that matches by wildcard.
+	publisher.Publish(testTopic, opts, wamp.List{"hello world"}, nil)
+
+	// Make sure the event was received by subscriber1
+	select {
+	case <-sync1:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Subscriber1 did not get published event")
+	}
+
+	// Make sure the event was not received by subscriber2
+	select {
+	case <-sync2:
+		t.Fatal("Subscriber2 received published event")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	err = subscriber1.Close()
+	if err != nil {
+		t.Fatal("Failed to disconnect client:", err)
+	}
+	err = subscriber2.Close()
+	if err != nil {
+		t.Fatal("Failed to disconnect client:", err)
+	}
+}
+
+func TestBlacklistAttribute(t *testing.T) {
+	// Setup subscriber1
+	subscriber1, err := connectClientDetails(wamp.Dict{"org_id": "spirent"})
+	if err != nil {
+		t.Fatal("Failed to connect client:", err)
+	}
+	sync1 := make(chan struct{})
+	evtHandler1 := func(args wamp.List, kwargs wamp.Dict, details wamp.Dict) {
+		sync1 <- struct{}{}
+	}
+	err = subscriber1.Subscribe(testTopic, evtHandler1, nil)
+	if err != nil {
+		t.Fatal("subscribe error:", err)
+	}
+
+	// Setup subscriber2
+	subscriber2, err := connectClientDetails(wamp.Dict{"org_id": "other"})
+	if err != nil {
+		t.Fatal("Failed to connect client:", err)
+	}
+	sync2 := make(chan struct{})
+	evtHandler2 := func(args wamp.List, kwargs wamp.Dict, details wamp.Dict) {
+		sync1 <- struct{}{}
+	}
+	err = subscriber2.Subscribe(testTopic, evtHandler2, nil)
+	if err != nil {
+		t.Fatal("subscribe error:", err)
+	}
+
+	// Connect publisher
+	publisher, err := connectClient()
+	if err != nil {
+		t.Fatal("Failed to connect client:", err)
+	}
+
+	opts := wamp.Dict{"exclude_org_id": wamp.List{"other", "bagduy"}}
+
+	// Publish an event to something that matches by wildcard.
+	publisher.Publish(testTopic, opts, wamp.List{"hello world"}, nil)
+
+	// Make sure the event was received by subscriber1
+	select {
+	case <-sync1:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Subscriber1 did not get published event")
+	}
+
+	// Make sure the event was not received by subscriber2
+	select {
+	case <-sync2:
+		t.Fatal("Subscriber2 received published event")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	err = subscriber1.Close()
+	if err != nil {
+		t.Fatal("Failed to disconnect client:", err)
+	}
+	err = subscriber2.Close()
+	if err != nil {
+		t.Fatal("Failed to disconnect client:", err)
+	}
+}

--- a/aat/sessionmeta_test.go
+++ b/aat/sessionmeta_test.go
@@ -48,6 +48,16 @@ func TestMetaEventOnJoin(t *testing.T) {
 		t.Fatal("subscribe error:", err)
 	}
 
+	// Wait for any event from subscriber joining.
+	var timeout bool
+	for !timeout {
+		select {
+		case <-errChan:
+		case <-time.After(200 * time.Millisecond):
+			timeout = true
+		}
+	}
+
 	// Connect client to generate wamp.session.on_join event.
 	sess, err := connectClient()
 	if err != nil {

--- a/auth/anonymous.go
+++ b/auth/anonymous.go
@@ -13,7 +13,7 @@ var AnonymousAuth Authenticator = &anonymousAuth{}
 func (a *anonymousAuth) Authenticate(details wamp.Dict, client wamp.Peer) (*wamp.Welcome, error) {
 	// Create welcome details containing auth info.
 	details = wamp.Dict{
-		"authid":       wamp.GlobalID(),
+		"authid":       string(wamp.GlobalID()),
 		"authmethod":   "anonymous",
 		"authrole":     "anonymous",
 		"authprovider": "static",

--- a/router/broker.go
+++ b/router/broker.go
@@ -441,7 +441,7 @@ func (b *broker) removeSession(sub *Session) {
 func (b *broker) pubEvent(pub *Session, msg *wamp.Publish, pubID wamp.ID, subs map[wamp.ID]*Session, excludePublisher, sendTopic, disclose bool) {
 	// Get blacklists and whitelists, if any, from publish message.
 	blIDs, wlIDs, blMap, wlMap := msgBlackWhiteLists(msg)
-	// Check is any filtering is needed.
+	// Check if any filtering is needed.
 	var filter bool
 	if len(blIDs) != 0 || len(wlIDs) != 0 || len(blMap) != 0 || len(wlMap) != 0 {
 		filter = true
@@ -626,7 +626,7 @@ func publishAllowed(sub *Session, blIDs, wlIDs []wamp.ID, blMap, wlMap map[strin
 	// Check blacklists to see if session has a value in any blacklist.
 	if len(blMap) != 0 {
 		for attr, vals := range blMap {
-			// Get the session attribute value to compate with blacklist.
+			// Get the session attribute value to compare with blacklist.
 			sessAttr := wamp.OptionString(sub.Details, attr)
 			if sessAttr == "" {
 				continue
@@ -658,7 +658,7 @@ func publishAllowed(sub *Session, blIDs, wlIDs []wamp.ID, blMap, wlMap map[strin
 	// Check whitelists to make sure session has value in each whitelist.
 	if len(wlMap) != 0 {
 		for attr, vals := range wlMap {
-			// Get the session attribute value to compate with whitelist.
+			// Get the session attribute value to compare with whitelist.
 			sessAttr := wamp.OptionString(sub.Details, attr)
 			if sessAttr == "" {
 				// Session does not have whitelisted value, so deny.


### PR DESCRIPTION
- Improved blacklist/whitelist handling so that the b/w lists are only extracted once from the publish message.
- Extend subscriber blacklist/whitelist for any string attribute match (i.e. `exclude_xxx = {val1, val2 ..}` and `eligible_xxx = {val1, val2, ..}`)
- Return all session details in session meta API on_join and get_session. 