### PR TITLE
Shutdown

### DIFF
--- a/aat/sessionmeta_test.go
+++ b/aat/sessionmeta_test.go
@@ -78,10 +78,6 @@ func TestMetaEventOnJoin(t *testing.T) {
 		t.Fatal(metaOnJoin, "meta even had wrong session ID")
 	}
 
-	err = subscriber.Unsubscribe(metaOnJoin)
-	if err != nil {
-		t.Fatal("unsubscribe error:", err)
-	}
 	err = subscriber.Close()
 	if err != nil {
 		t.Fatal("Failed to disconnect client:", err)
@@ -160,10 +156,6 @@ func TestMetaEventOnLeave(t *testing.T) {
 			"want", sess.ID())
 	}
 
-	err = subscriber.Unsubscribe(metaOnLeave)
-	if err != nil {
-		t.Fatal("unsubscribe error:", err)
-	}
 	err = subscriber.Close()
 	if err != nil {
 		t.Fatal("Failed to disconnect client:", err)
@@ -262,8 +254,6 @@ func TestMetaProcSessionCount(t *testing.T) {
 		t.Fatal("Session count should be same as first")
 	}
 
-	subscriber.Unsubscribe(metaOnJoin)
-	subscriber.Unsubscribe(metaOnLeave)
 	err = subscriber.Close()
 	if err != nil {
 		t.Fatal("Failed to disconnect client:", err)
@@ -377,8 +367,10 @@ func TestMetaProcSessionList(t *testing.T) {
 		t.Fatal("Session ID should not be in session list")
 	}
 
-	subscriber.Unsubscribe(metaOnLeave)
-	subscriber.Close()
+	err = subscriber.Close()
+	if err != nil {
+		t.Fatal("Failed to disconnect client:", err)
+	}
 
 	err = caller.Close()
 	if err != nil {
@@ -466,7 +458,6 @@ func TestMetaProcSessionGet(t *testing.T) {
 		t.Fatal("Expected error URI:", wamp.ErrNoSuchSession, "got", rpcErr.Err.Error)
 	}
 
-	subscriber.Unsubscribe(metaOnLeave)
 	err = subscriber.Close()
 	if err != nil {
 		t.Fatal("Failed to disconnect client:", err)

--- a/aat/sessionmeta_test.go
+++ b/aat/sessionmeta_test.go
@@ -82,13 +82,12 @@ func TestMetaEventOnJoin(t *testing.T) {
 	if err != nil {
 		t.Fatal("unsubscribe error:", err)
 	}
-
-	err = sess.Close()
+	err = subscriber.Close()
 	if err != nil {
 		t.Fatal("Failed to disconnect client:", err)
 	}
 
-	err = subscriber.Close()
+	err = sess.Close()
 	if err != nil {
 		t.Fatal("Failed to disconnect client:", err)
 	}
@@ -165,7 +164,6 @@ func TestMetaEventOnLeave(t *testing.T) {
 	if err != nil {
 		t.Fatal("unsubscribe error:", err)
 	}
-
 	err = subscriber.Close()
 	if err != nil {
 		t.Fatal("Failed to disconnect client:", err)
@@ -264,13 +262,17 @@ func TestMetaProcSessionCount(t *testing.T) {
 		t.Fatal("Session count should be same as first")
 	}
 
-	err = caller.Close()
+	subscriber.Unsubscribe(metaOnJoin)
+	subscriber.Unsubscribe(metaOnLeave)
+	err = subscriber.Close()
 	if err != nil {
 		t.Fatal("Failed to disconnect client:", err)
 	}
 
-	subscriber.Unsubscribe(metaOnJoin)
-	subscriber.Unsubscribe(metaOnLeave)
+	err = caller.Close()
+	if err != nil {
+		t.Fatal("Failed to disconnect client:", err)
+	}
 }
 
 func TestMetaProcSessionList(t *testing.T) {
@@ -375,13 +377,13 @@ func TestMetaProcSessionList(t *testing.T) {
 		t.Fatal("Session ID should not be in session list")
 	}
 
+	subscriber.Unsubscribe(metaOnLeave)
+	subscriber.Close()
+
 	err = caller.Close()
 	if err != nil {
 		t.Fatal("Failed to disconnect client:", err)
 	}
-
-	subscriber.Unsubscribe(metaOnLeave)
-	subscriber.Close()
 }
 
 func TestMetaProcSessionGet(t *testing.T) {
@@ -464,11 +466,14 @@ func TestMetaProcSessionGet(t *testing.T) {
 		t.Fatal("Expected error URI:", wamp.ErrNoSuchSession, "got", rpcErr.Err.Error)
 	}
 
-	err = caller.Close()
+	subscriber.Unsubscribe(metaOnLeave)
+	err = subscriber.Close()
 	if err != nil {
 		t.Fatal("Failed to disconnect client:", err)
 	}
 
-	subscriber.Unsubscribe(metaOnLeave)
-	subscriber.Close()
+	err = caller.Close()
+	if err != nil {
+		t.Fatal("Failed to disconnect client:", err)
+	}
 }

--- a/broker.go
+++ b/broker.go
@@ -33,8 +33,8 @@ const (
 	detailTopic = "topic"
 )
 
-// Features supported by this broker.
-var brokerFeatures = wamp.Dict{
+// Role information for this broker.
+var brokerRole = wamp.Dict{
 	"features": wamp.Dict{
 		featureSubBlackWhiteListing: true,
 		featurePatternSub:           true,
@@ -80,11 +80,9 @@ type Broker interface {
 	// Close shuts down the broker.
 	Close()
 
-	// Features returns the features supported by this broker.
-	//
-	// The data returned is suitable for use as the "features" section of the
-	// broker role in a WELCOME message.
-	Features() wamp.Dict
+	// Role returns the role information for the "broker" role.  The data
+	// returned is suitable for use as broker role info in a WELCOME message.
+	Role() wamp.Dict
 }
 
 type broker struct {
@@ -146,9 +144,9 @@ func NewBroker(logger stdlog.StdLog, strictURI, allowDisclose, debug bool) Broke
 	return b
 }
 
-// Features returns the features supported by this broker.
-func (b *broker) Features() wamp.Dict {
-	return brokerFeatures
+// Role returns the role information for the "broker" role.
+func (b *broker) Role() wamp.Dict {
+	return brokerRole
 }
 
 // Publish publishes an event to subscribers.

--- a/broker_test.go
+++ b/broker_test.go
@@ -159,8 +159,7 @@ func TestRemove(t *testing.T) {
 	rsp = <-sess.Recv()
 	subID2 := rsp.(*wamp.Subscribed).Subscription
 
-	// Subscribe to unregister meta events
-	broker.RemoveSession(sess)
+	broker.RemoveSession(sess, true)
 
 	// Wait for another subscriber as a way to wait for the RemoveSession to
 	// complete.

--- a/broker_test.go
+++ b/broker_test.go
@@ -159,7 +159,7 @@ func TestRemove(t *testing.T) {
 	rsp = <-sess.Recv()
 	subID2 := rsp.(*wamp.Subscribed).Subscription
 
-	broker.RemoveSession(sess, true)
+	broker.RemoveSession(sess)
 
 	// Wait for another subscriber as a way to wait for the RemoveSession to
 	// complete.

--- a/dealer.go
+++ b/dealer.go
@@ -100,7 +100,7 @@ type Dealer interface {
 	Error(msg *wamp.Error)
 
 	// Remove a callee's registrations.
-	RemoveSession(*Session, bool)
+	RemoveSession(*Session)
 
 	// Close shuts down the dealer.
 	Close()
@@ -351,13 +351,13 @@ func (d *dealer) Error(msg *wamp.Error) {
 	}
 }
 
-func (d *dealer) RemoveSession(sess *Session, disableMeta bool) {
+func (d *dealer) RemoveSession(sess *Session) {
 	if sess == nil {
 		// No session specified, no session removed.
 		return
 	}
 	d.actionChan <- func() {
-		d.removeSession(sess, disableMeta)
+		d.removeSession(sess)
 	}
 }
 
@@ -860,15 +860,11 @@ func (d *dealer) error(msg *wamp.Error) {
 	})
 }
 
-func (d *dealer) removeSession(callee *Session, disableMeta bool) {
+func (d *dealer) removeSession(callee *Session) {
 	for regID := range d.calleeRegIDSet[callee] {
 		delReg, err := d.delCalleeReg(callee, regID)
 		if err != nil {
 			panic("!!! Callee had ID of nonexistent registration")
-		}
-
-		if disableMeta {
-			continue
 		}
 
 		// Publish wamp.registration.on_unregister meta event.  Fired when a

--- a/dealer.go
+++ b/dealer.go
@@ -42,8 +42,8 @@ const (
 	cancelModeSkip       = "skip"
 )
 
-// Features supported by this dealer.
-var dealerFeatures = wamp.Dict{
+// Role information for this broker.
+var dealerRole = wamp.Dict{
 	"features": wamp.Dict{
 		featureCallCanceling:   true,
 		featureCallTimeout:     true,
@@ -105,11 +105,9 @@ type Dealer interface {
 	// Close shuts down the dealer.
 	Close()
 
-	// Features returns the features supported by this dealer.
-	//
-	// The data returned is suitable for use as the "features" section of the
-	// dealer role in a WELCOME message.
-	Features() wamp.Dict
+	// Role returns the role information for the "dealer" role.  The data
+	// returned is suitable for use as broker role info in a WELCOME message.
+	Role() wamp.Dict
 
 	// RegList retrieves registration IDs listed according to match policies.
 	RegList(*wamp.Invocation) wamp.Message
@@ -237,9 +235,9 @@ func NewDealer(metaClient wamp.Peer, logger stdlog.StdLog, strictURI, allowDiscl
 	return d
 }
 
-// Features returns the features supported by this dealer.
-func (d *dealer) Features() wamp.Dict {
-	return dealerFeatures
+// Role returns the role information for the "dealer" role.
+func (d *dealer) Role() wamp.Dict {
+	return dealerRole
 }
 
 // Register registers a callee to handle calls to a procedure.

--- a/dealer_test.go
+++ b/dealer_test.go
@@ -251,7 +251,7 @@ func TestRemovePeer(t *testing.T) {
 	}
 
 	// Test that removing the callee session removes the registration.
-	dealer.RemoveSession(sess)
+	dealer.RemoveSession(sess, true)
 
 	// Register as a way to sync with dealer.
 	sess2 := &Session{Peer: callee}
@@ -749,7 +749,7 @@ func TestSharedRegistrationFirst(t *testing.T) {
 	}
 
 	// Remove callee1
-	dealer.RemoveSession(calleeSess1)
+	dealer.RemoveSession(calleeSess1, false)
 	if err = checkMetaReg(metaClient, calleeSess1.ID); err != nil {
 		t.Fatal("Registration meta event fail:", err)
 	}
@@ -899,7 +899,7 @@ func TestSharedRegistrationLast(t *testing.T) {
 	}
 
 	// Remove callee2
-	dealer.RemoveSession(calleeSess2)
+	dealer.RemoveSession(calleeSess2, false)
 	if err = checkMetaReg(metaClient, calleeSess2.ID); err != nil {
 		t.Fatal("Registration meta event fail:", err)
 	}

--- a/dealer_test.go
+++ b/dealer_test.go
@@ -251,7 +251,7 @@ func TestRemovePeer(t *testing.T) {
 	}
 
 	// Test that removing the callee session removes the registration.
-	dealer.RemoveSession(sess, true)
+	dealer.RemoveSession(sess)
 
 	// Register as a way to sync with dealer.
 	sess2 := &Session{Peer: callee}
@@ -749,7 +749,7 @@ func TestSharedRegistrationFirst(t *testing.T) {
 	}
 
 	// Remove callee1
-	dealer.RemoveSession(calleeSess1, false)
+	dealer.RemoveSession(calleeSess1)
 	if err = checkMetaReg(metaClient, calleeSess1.ID); err != nil {
 		t.Fatal("Registration meta event fail:", err)
 	}
@@ -899,7 +899,7 @@ func TestSharedRegistrationLast(t *testing.T) {
 	}
 
 	// Remove callee2
-	dealer.RemoveSession(calleeSess2, false)
+	dealer.RemoveSession(calleeSess2)
 	if err = checkMetaReg(metaClient, calleeSess2.ID); err != nil {
 		t.Fatal("Registration meta event fail:", err)
 	}

--- a/realm.go
+++ b/realm.go
@@ -161,7 +161,7 @@ func (r *realm) close() {
 	r.waitHandlers.Wait()
 
 	if r.metaSess != nil {
-		// All normal handlers have exite, so now stop the meta session.  When
+		// All normal handlers have exited, so now stop the meta session.  When
 		// the meta client receives GOODBYE from the meta session, the meta
 		// session is done and will not try to publish anything more to the
 		// broker, and it is finally safe to exit and close the broker.
@@ -251,7 +251,7 @@ func (r *realm) onJoin(sess *Session) {
 //
 // If the session handler exited due to realm shutdown, then remove the session
 // from broker, dealer, and realm without generating meta events.  If not
-// shutdown, then remove thesession and generate meta events as appropriate.
+// shutdown, then remove the session and generate meta events as appropriate.
 //
 // There is no point to generating meta events at realm shutdown since those
 // events would only be received by meta event subscribers that had not been
@@ -295,7 +295,7 @@ func (r *realm) handleSession(sess *Session) error {
 		return err
 	}
 
-	// Ensure sesson is capable of receiving exit signal before releasing lock.
+	// Ensure session is capable of receiving exit signal before releasing lock.
 	r.onJoin(sess)
 	r.closeLock.Unlock()
 
@@ -315,7 +315,7 @@ func (r *realm) handleSession(sess *Session) error {
 // the router.
 func (r *realm) handleInboundMessages(sess *Session) bool {
 	if r.debug {
-		defer r.log.Println("Ended sesion", sess)
+		defer r.log.Println("Ended session", sess)
 	}
 	recvChan := sess.Recv()
 	for {
@@ -502,7 +502,7 @@ func (r *realm) registerMetaProcedure(procedure wamp.URI, f func(*wamp.Invocatio
 		err, ok := msg.(*wamp.Error)
 		if !ok {
 			r.log.Println("PANIC! Received unexpected", msg.MessageType())
-			panic("cannot register metapocedure")
+			panic("cannot register meta procedure")
 		}
 		errMsg := fmt.Sprintf(
 			"PANIC! Failed to register session meta procedure: %v", err.Error)

--- a/realm.go
+++ b/realm.go
@@ -264,8 +264,12 @@ func (r *realm) onLeave(sess *Session, shutdown bool) {
 	sync := make(chan struct{})
 	r.actionChan <- func() {
 		delete(r.clients, sess.ID)
-		r.dealer.RemoveSession(sess, shutdown)
-		r.broker.RemoveSession(sess, shutdown)
+		// If realm is shutdown, do not bother to remove session from broker
+		// and dealer.  They will be closed after sessions are closed.
+		if !shutdown {
+			r.dealer.RemoveSession(sess)
+			r.broker.RemoveSession(sess)
+		}
 		sync <- struct{}{}
 	}
 	<-sync

--- a/realm.go
+++ b/realm.go
@@ -449,8 +449,8 @@ func (r *realm) authClient(client wamp.Peer, details wamp.Dict) (*wamp.Welcome, 
 	}
 	welcome.Details["authmethod"] = method
 	welcome.Details["roles"] = wamp.Dict{
-		"broker": r.broker.Features(),
-		"dealer": r.dealer.Features(),
+		"broker": r.broker.Role(),
+		"dealer": r.dealer.Role(),
 	}
 	return welcome, nil
 }


### PR DESCRIPTION
I believe this fixes the possible send on closed channel error, which was do to prematurely closing the realm's action channel.

The realm shutdown procedure has also been clarified.

Meta events are not generated during shutdown.  There is no point to generating meta events at realm shutdown since those events would only be received by meta event subscribers that had not been removed yet, and clients are removed in any order. 