### PR TITLE
Fix goroutine leak when canceling call.  Multiple calls to Close() OK.

### DIFF
--- a/aat/pubsub_test.go
+++ b/aat/pubsub_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fortytw2/leaktest"
 	"github.com/gammazero/nexus/wamp"
 )
 
@@ -16,6 +17,8 @@ const (
 )
 
 func TestPubSub(t *testing.T) {
+	defer leaktest.Check(t)()
+
 	// Connect subscriber session.
 	subscriber, err := connectClient()
 	if err != nil {
@@ -73,6 +76,7 @@ func TestPubSub(t *testing.T) {
 }
 
 func TestPubSubWildcard(t *testing.T) {
+	defer leaktest.Check(t)()
 	// Connect subscriber session.
 	subscriber, err := connectClient()
 	if err != nil {
@@ -135,6 +139,7 @@ func TestPubSubWildcard(t *testing.T) {
 }
 
 func TestUnsubscribeWrongTopic(t *testing.T) {
+	defer leaktest.Check(t)()
 	// Connect subscriber session.
 	subscriber, err := connectClient()
 	if err != nil {
@@ -197,6 +202,7 @@ func TestUnsubscribeWrongTopic(t *testing.T) {
 }
 
 func TestSubscribeBurst(t *testing.T) {
+	defer leaktest.Check(t)()
 	// Connect subscriber session.
 	sub, err := connectClient()
 	if err != nil {

--- a/aat/rpc_test.go
+++ b/aat/rpc_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fortytw2/leaktest"
 	"github.com/gammazero/nexus/client"
 	"github.com/gammazero/nexus/wamp"
 )
 
 func TestRPCRegisterAndCall(t *testing.T) {
+	defer leaktest.Check(t)()
 	// Connect callee session.
 	callee, err := connectClient()
 	if err != nil {
@@ -72,6 +74,7 @@ func TestRPCRegisterAndCall(t *testing.T) {
 }
 
 func TestRPCCallUnregistered(t *testing.T) {
+	defer leaktest.Check(t)()
 	// Connect caller session.
 	caller, err := connectClient()
 	if err != nil {
@@ -96,6 +99,7 @@ func TestRPCCallUnregistered(t *testing.T) {
 }
 
 func TestRPCUnregisterUnregistered(t *testing.T) {
+	defer leaktest.Check(t)()
 	// Connect caller session.
 	callee, err := connectClient()
 	if err != nil {
@@ -114,6 +118,7 @@ func TestRPCUnregisterUnregistered(t *testing.T) {
 }
 
 func TestRPCCancelCall(t *testing.T) {
+	defer leaktest.Check(t)()
 	// Connect callee session.
 	callee, err := connectClient()
 	if err != nil {

--- a/aat/sessionmeta_test.go
+++ b/aat/sessionmeta_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fortytw2/leaktest"
 	"github.com/gammazero/nexus/client"
 	"github.com/gammazero/nexus/wamp"
 )
@@ -20,6 +21,7 @@ const (
 )
 
 func TestMetaEventOnJoin(t *testing.T) {
+	defer leaktest.Check(t)()
 	// Connect subscriber session.
 	subscriber, err := connectClient()
 	if err != nil {
@@ -90,6 +92,7 @@ func TestMetaEventOnJoin(t *testing.T) {
 }
 
 func TestMetaEventOnLeave(t *testing.T) {
+	defer leaktest.Check(t)()
 	// Connect subscriber session.
 	subscriber, err := connectClient()
 	if err != nil {
@@ -163,6 +166,7 @@ func TestMetaEventOnLeave(t *testing.T) {
 }
 
 func TestMetaProcSessionCount(t *testing.T) {
+	defer leaktest.Check(t)()
 	// Connect caller.
 	caller, err := connectClient()
 	if err != nil {
@@ -266,6 +270,7 @@ func TestMetaProcSessionCount(t *testing.T) {
 }
 
 func TestMetaProcSessionList(t *testing.T) {
+	defer leaktest.Check(t)()
 	// Connect a client to session.
 	sess, err := connectClient()
 	if err != nil {
@@ -379,6 +384,7 @@ func TestMetaProcSessionList(t *testing.T) {
 }
 
 func TestMetaProcSessionGet(t *testing.T) {
+	defer leaktest.Check(t)()
 	// Connect a client to session.
 	sess, err := connectClient()
 	if err != nil {

--- a/router.go
+++ b/router.go
@@ -321,4 +321,5 @@ func (r *router) Close() {
 	<-sync
 	// Wait for all existing realms to close.
 	r.waitRealms.Wait()
+	close(r.actionChan)
 }

--- a/router_test.go
+++ b/router_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fortytw2/leaktest"
 	"github.com/gammazero/nexus/stdlog"
 	"github.com/gammazero/nexus/transport"
 	"github.com/gammazero/nexus/wamp"
@@ -94,6 +95,7 @@ func testClient(r Router) (*Session, error) {
 }
 
 func TestHandshake(t *testing.T) {
+	defer leaktest.Check(t)()
 	r, err := newTestRouter()
 	if err != nil {
 		t.Fatal(err)
@@ -116,6 +118,7 @@ func TestHandshake(t *testing.T) {
 }
 
 func TestHandshakeBadRealm(t *testing.T) {
+	defer leaktest.Check(t)()
 	r, err := newTestRouter()
 	if err != nil {
 		t.Error(err)
@@ -140,6 +143,7 @@ func TestHandshakeBadRealm(t *testing.T) {
 }
 
 func TestRouterSubscribe(t *testing.T) {
+	defer leaktest.Check(t)()
 	const testTopic = wamp.URI("some.uri")
 	r, err := newTestRouter()
 	if err != nil {
@@ -192,6 +196,7 @@ func TestRouterSubscribe(t *testing.T) {
 }
 
 func TestPublishAcknowledge(t *testing.T) {
+	defer leaktest.Check(t)()
 	r, err := newTestRouter()
 	if err != nil {
 		t.Error(err)
@@ -274,6 +279,7 @@ func TestPublishNoAcknowledge(t *testing.T) {
 }
 
 func TestRouterCall(t *testing.T) {
+	defer leaktest.Check(t)()
 	r, err := newTestRouter()
 	if err != nil {
 		t.Error(err)
@@ -344,6 +350,7 @@ func TestRouterCall(t *testing.T) {
 }
 
 func TestSessionMetaProcedures(t *testing.T) {
+	defer leaktest.Check(t)()
 	r, err := newTestRouter()
 	if err != nil {
 		t.Error(err)
@@ -466,6 +473,7 @@ func TestSessionMetaProcedures(t *testing.T) {
 }
 
 func TestRegistrationMetaProcedures(t *testing.T) {
+	defer leaktest.Check(t)()
 	r, err := newTestRouter()
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
- Fix goroutine leak when canceling call
- Multiple calls to client.Close() are OK (previously caused panic)
- Calling client.Close() after failing to join realm is OK (previously caused panic)
