### PR TITLE
Joining a realm is part of client creation.

### DIFF
--- a/aat/sessionfilter_test.go
+++ b/aat/sessionfilter_test.go
@@ -4,12 +4,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gammazero/nexus/client"
 	"github.com/gammazero/nexus/wamp"
 )
 
 func TestWhitelistAttribute(t *testing.T) {
 	// Setup subscriber1
-	subscriber1, err := connectClientDetails(wamp.Dict{"org_id": "zcorp"})
+	cfg := client.ClientConfig{
+		Realm:        testRealm,
+		HelloDetails: wamp.Dict{"org_id": "zcorp"},
+	}
+	subscriber1, err := connectClientCfg(cfg)
 	if err != nil {
 		t.Fatal("Failed to connect client:", err)
 	}
@@ -23,7 +28,11 @@ func TestWhitelistAttribute(t *testing.T) {
 	}
 
 	// Setup subscriber2
-	subscriber2, err := connectClientDetails(wamp.Dict{"org_id": "other"})
+	cfg = client.ClientConfig{
+		Realm:        testRealm,
+		HelloDetails: wamp.Dict{"org_id": "other"},
+	}
+	subscriber2, err := connectClientCfg(cfg)
 	if err != nil {
 		t.Fatal("Failed to connect client:", err)
 	}
@@ -109,7 +118,11 @@ func TestWhitelistAttribute(t *testing.T) {
 
 func TestBlacklistAttribute(t *testing.T) {
 	// Setup subscriber1
-	subscriber1, err := connectClientDetails(wamp.Dict{"org_id": "zcorp"})
+	cfg := client.ClientConfig{
+		Realm:        testRealm,
+		HelloDetails: wamp.Dict{"org_id": "zcorp"},
+	}
+	subscriber1, err := connectClientCfg(cfg)
 	if err != nil {
 		t.Fatal("Failed to connect client:", err)
 	}
@@ -123,7 +136,11 @@ func TestBlacklistAttribute(t *testing.T) {
 	}
 
 	// Setup subscriber2
-	subscriber2, err := connectClientDetails(wamp.Dict{"org_id": "other"})
+	cfg = client.ClientConfig{
+		Realm:        testRealm,
+		HelloDetails: wamp.Dict{"org_id": "other"},
+	}
+	subscriber2, err := connectClientCfg(cfg)
 	if err != nil {
 		t.Fatal("Failed to connect client:", err)
 	}

--- a/client/local.go
+++ b/client/local.go
@@ -1,8 +1,6 @@
 package client
 
 import (
-	"time"
-
 	"github.com/gammazero/nexus"
 	"github.com/gammazero/nexus/stdlog"
 	"github.com/gammazero/nexus/transport"
@@ -11,7 +9,7 @@ import (
 // NewLocalClient creates a new client directly connected to embedded router
 //
 // JoinRealm must be called before other client functions.
-func NewLocalClient(router nexus.Router, responseTimeout time.Duration, logger stdlog.StdLog) (*Client, error) {
+func NewLocalClient(router nexus.Router, cfg ClientConfig, logger stdlog.StdLog) (*Client, error) {
 	localSide, routerSide := transport.LinkedPeers(logger)
 
 	go func() {
@@ -20,5 +18,5 @@ func NewLocalClient(router nexus.Router, responseTimeout time.Duration, logger s
 		}
 	}()
 
-	return NewClient(localSide, responseTimeout, logger), nil
+	return NewClient(localSide, cfg, logger)
 }

--- a/client/websocket.go
+++ b/client/websocket.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"crypto/tls"
-	"time"
 
 	"github.com/gammazero/nexus/stdlog"
 	"github.com/gammazero/nexus/transport"
@@ -18,10 +17,11 @@ const (
 // URL and using the specified serialization.
 //
 // JoinRealm must be called before other client functions.
-func NewWebsocketClient(url string, serialization serialize.Serialization, tlscfg *tls.Config, dial transport.DialFunc, responseTimeout time.Duration, logger stdlog.StdLog) (*Client, error) {
-	p, err := transport.ConnectWebsocketPeer(url, serialization, tlscfg, dial, logger)
+func NewWebsocketClient(url string, serialization serialize.Serialization, tlscfg *tls.Config, dial transport.DialFunc, cfg ClientConfig, logger stdlog.StdLog) (*Client, error) {
+	p, err := transport.ConnectWebsocketPeer(url, serialization, tlscfg, dial,
+		logger)
 	if err != nil {
 		return nil, err
 	}
-	return NewClient(p, responseTimeout, logger), nil
+	return NewClient(p, cfg, logger)
 }

--- a/examples/pubsub/publisher/publisher.go
+++ b/examples/pubsub/publisher/publisher.go
@@ -12,18 +12,16 @@ const exampleTopic = "example.hello"
 
 func main() {
 	logger := log.New(os.Stdout, "PUBLISHER> ", log.LstdFlags)
+	cfg := client.ClientConfig{
+		Realm: "nexus.examples",
+	}
+	// Connect publisher session.
 	publisher, err := client.NewWebsocketClient(
-		"ws://localhost:8000/", client.JSON, nil, nil, 0, logger)
+		"ws://localhost:8000/", client.JSON, nil, nil, cfg, logger)
 	if err != nil {
 		logger.Fatal(err)
 	}
 	defer publisher.Close()
-
-	// Connect publisher session.
-	_, err = publisher.JoinRealm("nexus.examples", nil, nil)
-	if err != nil {
-		logger.Fatal(err)
-	}
 
 	// Publish to topic.
 	args := wamp.List{"hello world"}

--- a/examples/pubsub/subscriber/subscriber.go
+++ b/examples/pubsub/subscriber/subscriber.go
@@ -14,18 +14,16 @@ const exampleTopic = "example.hello"
 
 func main() {
 	logger := log.New(os.Stdout, "SUBSCRIBER> ", log.LstdFlags)
+	cfg := client.ClientConfig{
+		Realm: "nexus.examples",
+	}
+	// Connect subscriber session.
 	subscriber, err := client.NewWebsocketClient(
-		"ws://localhost:8000/", client.JSON, nil, nil, 0, logger)
+		"ws://localhost:8000/", client.JSON, nil, nil, cfg, logger)
 	if err != nil {
 		logger.Fatal(err)
 	}
 	defer subscriber.Close()
-
-	// Connect subscriber session.
-	_, err = subscriber.JoinRealm("nexus.examples", nil, nil)
-	if err != nil {
-		logger.Fatal(err)
-	}
 
 	// Define function to handle events received.
 	evtHandler := func(args wamp.List, kwargs wamp.Dict, details wamp.Dict) {

--- a/examples/rpc/client_callee/callee.go
+++ b/examples/rpc/client_callee/callee.go
@@ -13,18 +13,16 @@ import (
 
 func main() {
 	logger := log.New(os.Stdout, "CALLEE> ", log.LstdFlags)
+	cfg := client.ClientConfig{
+		Realm: "nexus.examples",
+	}
+	// Connect callee session.
 	callee, err := client.NewWebsocketClient(
-		"ws://localhost:8000/", client.JSON, nil, nil, 0, logger)
+		"ws://localhost:8000/", client.JSON, nil, nil, cfg, logger)
 	if err != nil {
 		logger.Fatal(err)
 	}
 	defer callee.Close()
-
-	// Connect callee session.
-	_, err = callee.JoinRealm("nexus.examples", nil, nil)
-	if err != nil {
-		logger.Fatal(err)
-	}
 
 	// Register procedure "sum"
 	procName := "sum"

--- a/examples/rpc/client_caller/caller.go
+++ b/examples/rpc/client_caller/caller.go
@@ -12,18 +12,16 @@ import (
 
 func main() {
 	logger := log.New(os.Stderr, "CALLER> ", log.LstdFlags)
+	cfg := client.ClientConfig{
+		Realm: "nexus.examples",
+	}
+	// Connect caller session.
 	caller, err := client.NewWebsocketClient(
-		"ws://localhost:8000/", client.JSON, nil, nil, 0, logger)
+		"ws://localhost:8000/", client.JSON, nil, nil, cfg, logger)
 	if err != nil {
 		logger.Fatal(err)
 	}
 	defer caller.Close()
-
-	// Connect callee session.
-	_, err = caller.JoinRealm("nexus.examples", nil, nil)
-	if err != nil {
-		logger.Fatal(err)
-	}
 
 	// Register procedure "sum"
 	procName := "sum"

--- a/examples/rpc/server_embedded_callee/server.go
+++ b/examples/rpc/server_embedded_callee/server.go
@@ -29,19 +29,16 @@ func main() {
 	}
 	defer nxr.Close()
 
-	// Create local client.
 	logger := log.New(os.Stdout, "CALLEE> ", log.LstdFlags)
-	callee, err := client.NewLocalClient(nxr, 0, logger)
+	cfg := client.ClientConfig{
+		Realm: "nexus.examples",
+	}
+	// Create local callee client.
+	callee, err := client.NewLocalClient(nxr, cfg, logger)
 	if err != nil {
 		logger.Fatal(err)
 	}
 	defer callee.Close()
-
-	// Connect callee session.
-	_, err = callee.JoinRealm("nexus.examples", nil, nil)
-	if err != nil {
-		logger.Fatal(err)
-	}
 
 	// Register procedure "sum"
 	procName := "sum"


### PR DESCRIPTION
This simplifies the code both inside client and outside in the use of the client.

- Client configuration makes more sense.
- Simpler for users to create clients and inspect errors.
- Removes internal and external complications of having a client that may or may not have joined a realm.
- Client shutdown logic much simpler. 