### PR TITLE
Authorize() returns optional reason string for client

### DIFF
--- a/aat/auth_test.go
+++ b/aat/auth_test.go
@@ -136,7 +136,7 @@ func TestAuthz(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected error")
 	}
-	if !strings.HasSuffix(err.Error(), "wamp.error.not_authorized: Cannot contact LDAP server") {
+	if !strings.HasSuffix(err.Error(), "wamp.error.authorization_failed: Cannot contact LDAP server") {
 		t.Fatal("Did not get expected error message with reason, got:", err)
 	}
 }

--- a/aat/auth_test.go
+++ b/aat/auth_test.go
@@ -134,6 +134,9 @@ func TestAuthz(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected error")
 	}
+	if !strings.HasSuffix(err.Error(), "wamp.error.not_authorized: Cannot contact LDAP server") {
+		t.Fatal("Did not get expected error message with reason")
+	}
 
 	subscriber.Close()
 	caller.Close()

--- a/aat/auth_test.go
+++ b/aat/auth_test.go
@@ -76,12 +76,14 @@ func TestAuthz(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to connect client:", err)
 	}
+	defer subscriber.Close()
 
 	// Connect caller.
 	caller, err := connectClientCfg(cfg)
 	if err != nil {
 		t.Fatal("Failed to connect client:", err)
 	}
+	defer caller.Close()
 
 	// Check that subscriber does not have special info provided by authorizer.
 	ctx := context.Background()
@@ -137,9 +139,6 @@ func TestAuthz(t *testing.T) {
 	if !strings.HasSuffix(err.Error(), "wamp.error.not_authorized: Cannot contact LDAP server") {
 		t.Fatal("Did not get expected error message with reason, got:", err)
 	}
-
-	subscriber.Close()
-	caller.Close()
 }
 
 func testAuthFunc(d wamp.Dict, c wamp.Dict) (string, wamp.Dict) {

--- a/aat/auth_test.go
+++ b/aat/auth_test.go
@@ -135,7 +135,7 @@ func TestAuthz(t *testing.T) {
 		t.Fatal("Expected error")
 	}
 	if !strings.HasSuffix(err.Error(), "wamp.error.not_authorized: Cannot contact LDAP server") {
-		t.Fatal("Did not get expected error message with reason")
+		t.Fatal("Did not get expected error message with reason, got:", err)
 	}
 
 	subscriber.Close()

--- a/aat/main_test.go
+++ b/aat/main_test.go
@@ -1,6 +1,7 @@
 package aat
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -43,21 +44,21 @@ var (
 
 type testAuthz struct{}
 
-func (a *testAuthz) Authorize(sess *nexus.Session, msg wamp.Message) (bool, string, error) {
+func (a *testAuthz) Authorize(sess *nexus.Session, msg wamp.Message) (bool, error) {
 	m, ok := msg.(*wamp.Subscribe)
 	if !ok {
 		if callMsg, ok := msg.(*wamp.Call); ok {
 			if callMsg.Procedure == wamp.URI("need.ldap.auth") {
-				return false, "Cannot contact LDAP server", nil
+				return false, errors.New("Cannot contact LDAP server")
 			}
 		}
-		return true, "", nil
+		return true, nil
 	}
 	if m.Topic == "nexus.interceptor" {
 		m.Topic = "nexus.interceptor.foobar.baz"
 	}
 	wamp.SetOption(sess.Details, "foobar", "baz")
-	return true, "", nil
+	return true, nil
 }
 
 func TestMain(m *testing.M) {

--- a/aat/main_test.go
+++ b/aat/main_test.go
@@ -43,22 +43,21 @@ var (
 
 type testAuthz struct{}
 
-func (a *testAuthz) Authorize(sess *nexus.Session, msg wamp.Message) (bool, error) {
+func (a *testAuthz) Authorize(sess *nexus.Session, msg wamp.Message) (bool, string, error) {
 	m, ok := msg.(*wamp.Subscribe)
 	if !ok {
 		if callMsg, ok := msg.(*wamp.Call); ok {
 			if callMsg.Procedure == wamp.URI("need.ldap.auth") {
-				// Cannot contact LDAP server
-				return false, nil
+				return false, "Cannot contact LDAP server", nil
 			}
 		}
-		return true, nil
+		return true, "", nil
 	}
 	if m.Topic == "nexus.interceptor" {
 		m.Topic = "nexus.interceptor.foobar.baz"
 	}
 	wamp.SetOption(sess.Details, "foobar", "baz")
-	return true, nil
+	return true, "", nil
 }
 
 func TestMain(m *testing.M) {

--- a/authorizer.go
+++ b/authorizer.go
@@ -6,14 +6,16 @@ import "github.com/gammazero/nexus/wamp"
 // to authorize request messages.
 type Authorizer interface {
 	// Authorize returns true if the request is authorized or false if not.  An
-	// error is returned if there is a failure to determine authorization.
+	// error is returned if there is a failure to determine authorization. If
+	// Authorize returns false, an optional reason string may be returned to
+	// provide additional information to the client.
 	//
 	// Since the Authorizer accesses both the session and the message through a
 	// pointer, the authorizer can alter the content of both the session and
 	// the message.  This allows the authorizer to also work as an interceptor
 	// of messages to change their content or change the sending session based
 	// on the intercepted message.
-	Authorize(*Session, wamp.Message) (bool, error)
+	Authorize(*Session, wamp.Message) (bool, string, error)
 }
 
 // authorizer is the default implementation that always returns authorized.
@@ -25,6 +27,6 @@ func NewAuthorizer() Authorizer {
 }
 
 // Authorize default implementation authorizes any session for all roles.
-func (a *authorizer) Authorize(sess *Session, msg wamp.Message) (bool, error) {
-	return true, nil
+func (a *authorizer) Authorize(sess *Session, msg wamp.Message) (bool, string, error) {
+	return true, "", nil
 }

--- a/authorizer.go
+++ b/authorizer.go
@@ -6,16 +6,15 @@ import "github.com/gammazero/nexus/wamp"
 // to authorize request messages.
 type Authorizer interface {
 	// Authorize returns true if the request is authorized or false if not.  An
-	// error is returned if there is a failure to determine authorization. If
-	// Authorize returns false, an optional reason string may be returned to
-	// provide additional information to the client.
+	// error is returned if there is a failure to determine authorization.
+	// This error is included in the ERROR response to the client.
 	//
 	// Since the Authorizer accesses both the session and the message through a
 	// pointer, the authorizer can alter the content of both the session and
 	// the message.  This allows the authorizer to also work as an interceptor
 	// of messages to change their content or change the sending session based
 	// on the intercepted message.
-	Authorize(*Session, wamp.Message) (bool, string, error)
+	Authorize(*Session, wamp.Message) (bool, error)
 }
 
 // authorizer is the default implementation that always returns authorized.
@@ -27,6 +26,6 @@ func NewAuthorizer() Authorizer {
 }
 
 // Authorize default implementation authorizes any session for all roles.
-func (a *authorizer) Authorize(sess *Session, msg wamp.Message) (bool, string, error) {
-	return true, "", nil
+func (a *authorizer) Authorize(sess *Session, msg wamp.Message) (bool, error) {
+	return true, nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -237,8 +237,8 @@ func (c *Client) Subscribe(topic string, fn EventHandler, options wamp.Dict) err
 		}
 		<-sync
 	case *wamp.Error:
-		return fmt.Errorf("error subscribing to topic '%v': %v", topic,
-			msg.Error)
+		return fmt.Errorf("error subscribing to topic '%v': %s", topic,
+			wampErrorString(msg))
 	default:
 		return unexpectedMsgError(msg, wamp.SUBSCRIBED)
 	}
@@ -301,7 +301,8 @@ func (c *Client) Unsubscribe(topic string) error {
 		// Already deleted the event handler for the topic.
 		return nil
 	case *wamp.Error:
-		return fmt.Errorf("Error unsubscribing to '%s': %v", topic, msg.Error)
+		return fmt.Errorf("Error unsubscribing to '%s': %s", topic,
+			wampErrorString(msg))
 	}
 	return unexpectedMsgError(msg, wamp.UNSUBSCRIBED)
 }
@@ -367,7 +368,8 @@ func (c *Client) Publish(topic string, options wamp.Dict, args wamp.List, kwargs
 	switch msg := msg.(type) {
 	case *wamp.Published:
 	case *wamp.Error:
-		return fmt.Errorf("error waiting for published message: %v", msg.Error)
+		return fmt.Errorf("error waiting for published message: %s",
+			wampErrorString(msg))
 	default:
 		return unexpectedMsgError(msg, wamp.PUBLISHED)
 	}
@@ -427,8 +429,8 @@ func (c *Client) Register(procedure string, fn InvocationHandler, options wamp.D
 				msg.Registration)
 		}
 	case *wamp.Error:
-		return fmt.Errorf("Error registering procedure '%v': %v", procedure,
-			msg.Error)
+		return fmt.Errorf("Error registering procedure '%v': %s", procedure,
+			wampErrorString(msg))
 	default:
 		return unexpectedMsgError(msg, wamp.REGISTERED)
 	}
@@ -491,7 +493,7 @@ func (c *Client) Unregister(procedure string) error {
 		// Already deleted the invocation handler for the procedure.
 	case *wamp.Error:
 		return fmt.Errorf("error unregistering procedure '%s': %v", procedure,
-			msg.Error)
+			wampErrorString(msg))
 	default:
 		return unexpectedMsgError(msg, wamp.UNREGISTERED)
 	}
@@ -615,16 +617,9 @@ type RPCError struct {
 
 // Error implements the error interface, returning an error string for the
 // RPCError.
-func (werr RPCError) Error() string {
-	e := fmt.Sprintf("error calling remote procedure '%s': %v", werr.Procedure,
-		werr.Err.Error)
-	if len(werr.Err.Arguments) != 0 {
-		e += fmt.Sprintf(": %v", werr.Err.Arguments)
-	}
-	if len(werr.Err.ArgumentsKw) != 0 {
-		e += fmt.Sprintf(": %v", werr.Err.ArgumentsKw)
-	}
-	return e
+func (rpce RPCError) Error() string {
+	return fmt.Sprintf("error calling remote procedure '%s': %s",
+		rpce.Procedure, wampErrorString(rpce.Err))
 }
 
 // Close causes the client to leave the realm it has joined, and closes the
@@ -761,6 +756,31 @@ func handleCRAuth(peer wamp.Peer, challenge *wamp.Challenge, details wamp.Dict, 
 
 	// Return the router's response to AUTHENTICATE, this should be WELCOME.
 	return msg, nil
+}
+
+// wampErrorString creates a message string that combines the Error, Arguments,
+// and the ArgumentsKw fields from a wamp.Error message.
+func wampErrorString(werr *wamp.Error) string {
+	e := fmt.Sprintf("%v", werr.Error)
+	if len(werr.Arguments) != 0 {
+		// Append ": arg1, arg2, ..., argN"
+		args := make([]string, len(werr.Arguments))
+		for i := range werr.Arguments {
+			args[i] = fmt.Sprint(werr.Arguments[i])
+		}
+		e += fmt.Sprintf(": %s", strings.Join(args, ", "))
+	}
+	if len(werr.ArgumentsKw) != 0 {
+		// Append ": k1=v1, k2=v2, ..., kN=vN"
+		kws := make([]string, len(werr.ArgumentsKw))
+		var i int
+		for k, v := range werr.ArgumentsKw {
+			kws[i] = fmt.Sprint(k, "=", v)
+			i++
+		}
+		e += fmt.Sprintf(": %s", strings.Join(kws, ", "))
+	}
+	return e
 }
 
 // unexpectedMsgError creates an error with information about the unexpected

--- a/client/client.go
+++ b/client/client.go
@@ -766,7 +766,11 @@ func wampErrorString(werr *wamp.Error) string {
 		// Append ": arg1, arg2, ..., argN"
 		args := make([]string, len(werr.Arguments))
 		for i := range werr.Arguments {
-			args[i] = fmt.Sprint(werr.Arguments[i])
+			s, ok := wamp.AsString(werr.Arguments[i])
+			if !ok {
+				s = fmt.Sprint(werr.Arguments[i])
+			}
+			args[i] = s
 		}
 		e += fmt.Sprintf(": %s", strings.Join(args, ", "))
 	}
@@ -775,7 +779,15 @@ func wampErrorString(werr *wamp.Error) string {
 		kws := make([]string, len(werr.ArgumentsKw))
 		var i int
 		for k, v := range werr.ArgumentsKw {
-			kws[i] = fmt.Sprint(k, "=", v)
+			ks, ok := wamp.AsString(k)
+			if !ok {
+				ks = fmt.Sprint(k)
+			}
+			vs, ok := wamp.AsString(v)
+			if !ok {
+				vs = fmt.Sprint(v)
+			}
+			kws[i] = fmt.Sprint(ks, "=", vs)
 			i++
 		}
 		e += fmt.Sprintf(": %s", strings.Join(kws, ", "))

--- a/realm.go
+++ b/realm.go
@@ -402,7 +402,7 @@ func (r *realm) handleInboundMessages(sess *Session) bool {
 // authorization fails or if the session is not authorized, then an error
 // response is returned to the client, and this method returns false.
 func (r *realm) authzMessage(sess *Session, msg wamp.Message) bool {
-	isAuthz, err := r.authorizer.Authorize(sess, msg)
+	isAuthz, reason, err := r.authorizer.Authorize(sess, msg)
 	if !isAuthz {
 		errRsp := &wamp.Error{Type: msg.MessageType()}
 		// Get the Request from request types of messages.
@@ -431,7 +431,11 @@ func (r *realm) authzMessage(sess *Session, msg wamp.Message) bool {
 		} else {
 			// Session not authorized.
 			errRsp.Error = wamp.ErrNotAuthorized
-			r.log.Println("Client", sess, msg.MessageType(), "not authorized")
+			r.log.Println("Client", sess, msg.MessageType(), "not authorized:",
+				reason)
+		}
+		if reason != "" {
+			errRsp.Arguments = wamp.List{reason}
 		}
 		sess.Send(errRsp)
 		return false

--- a/realm.go
+++ b/realm.go
@@ -430,7 +430,9 @@ func (r *realm) authzMessage(sess *Session, msg wamp.Message) bool {
 			errRsp.Arguments = wamp.List{err.Error()}
 			r.log.Println("Client", sess, "authorization failed:", err)
 		} else {
-			// Session not authorized.
+			// Session not authorized.  The inability to return a message is
+			// intentional, so as not to encourage returning information that
+			// could disclose any clues about authorization to an attacker.
 			errRsp.Error = wamp.ErrNotAuthorized
 			r.log.Println("Client", sess, msg.MessageType(), "not authorized")
 		}

--- a/realm.go
+++ b/realm.go
@@ -402,7 +402,7 @@ func (r *realm) handleInboundMessages(sess *Session) bool {
 // authorization fails or if the session is not authorized, then an error
 // response is returned to the client, and this method returns false.
 func (r *realm) authzMessage(sess *Session, msg wamp.Message) bool {
-	isAuthz, reason, err := r.authorizer.Authorize(sess, msg)
+	isAuthz, err := r.authorizer.Authorize(sess, msg)
 	if !isAuthz {
 		errRsp := &wamp.Error{Type: msg.MessageType()}
 		// Get the Request from request types of messages.
@@ -427,15 +427,12 @@ func (r *realm) authzMessage(sess *Session, msg wamp.Message) bool {
 		if err != nil {
 			// Error trying to authorize.  Include error message.
 			errRsp.Error = wamp.ErrAuthorizationFailed
+			errRsp.Arguments = wamp.List{err.Error()}
 			r.log.Println("Client", sess, "authorization failed:", err)
 		} else {
 			// Session not authorized.
 			errRsp.Error = wamp.ErrNotAuthorized
-			r.log.Println("Client", sess, msg.MessageType(), "not authorized:",
-				reason)
-		}
-		if reason != "" {
-			errRsp.Arguments = wamp.List{reason}
+			r.log.Println("Client", sess, msg.MessageType(), "not authorized")
 		}
 		sess.Send(errRsp)
 		return false


### PR DESCRIPTION
If `Authorize()` returns false, an optional reason string may be returned to provide additional information to the client about the unauthorized response, or the authorization failure.

This is a API change, so need to consider carefully.