### PR TITLE
RawSocket transport

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ test:
 	go test -race ./...
 	go test -race ./aat -websocket
 	go test ./aat -websocket -msgpack
+	go test -race ./aat -rawsocketunix
 
 service: $(SERVICE_DIR)/nexusd
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Nexus is a software package that provides a WAMP router library, client library,
 
 - **Concurrent Asynchronous I/O** Nexus supports large numbers of clients concurrently sending and receiving messages, and never blocks on I/O, even if a client becomes unresponsive.  See [Router Concurrency](https://github.com/gammazero/nexus/wiki/Router-Concurrency) for details.
 - **WAMP Advanced Profile Features**  This project implements most of the advanced profile features in WAMP v2.  See [current feature support](https://github.com/gammazero/nexus#advanced-profile-feature-support) provided by nexus.  Nexus also offers extended functionality for retrieving session information and for message filtering, giving clients more ability to decide where to send messages.
-- **Flexibility** Multiple transports and serialization options are supported, and more are being developed to maximize interoperability.  Currently nexus provides websocket and local (in-process) transports.  [JSON](https://en.wikipedia.org/wiki/JSON) and [MessagePack](http://msgpack.org/index.html) serialization is available over websockets.
+- **Flexibility** Multiple transports and serialization options are supported, and more are being developed to maximize interoperability.  Currently nexus provides websocket, rawsocket, and local (in-process) transports.  [JSON](https://en.wikipedia.org/wiki/JSON) and [MessagePack](http://msgpack.org/index.html) serialization is available over websockets and rawsockets.
 - **Security** TLS over websockets is included with the [Gorilla WebSocket](https://github.com/gorilla/websocket) package that nexus uses as its websocket implementation.  The nexus router library provides interfaces for integration of client authentication and authorization logic.
 
 ## Quick Start
@@ -60,7 +60,7 @@ Please read the [Contributing](https://github.com/gammazero/nexus/blob/master/CO
 
 ## Status
 
-A stable release of nexus is available with support for most advanced profile features.  Nexus is in active development, to add remaining advanced profile features (e.g. RawSocket transport), examples, automated tests, and documentation.
+A stable release of nexus is available with support for most advanced profile features.  Nexus is in active development, to add remaining advanced profile features, examples, automated tests, and documentation.
 
 ### TODO
 
@@ -68,7 +68,6 @@ These features listed here are being added.  If there are are specific items nee
 
 - more documentation (in progress)
 - advanced profile examples (in progress)
-- RawSocket transport (soon)
 - [CBOR](https://tools.ietf.org/html/rfc7049) Serialization (planned)
 - TLS config for `nexusd`
 - testament_meta_api
@@ -116,7 +115,7 @@ These features listed here are being added.  If there are are specific items nee
 | challenge-response authentication | Yes | 
 | cookie authentication | No |
 | ticket authentication | Yes |
-| rawsocket transport | No |
+| rawsocket transport | Yes |
 | batched WS transport | No |
 | longpoll transport | No |
 | session meta api | Yes |

--- a/client/client.go
+++ b/client/client.go
@@ -126,7 +126,8 @@ type Client struct {
 //
 // NOTE: This method is provided for clients that use a Peer implementation not
 // provided with the nexus package.  Generally, clients are created using the
-// NewLocalPeer() or NewWebsocketPeer() functions.
+// transport.LinkedPeers(), transport.ConnectWebsocketPeer(), or
+// transport.ConnectRawSocketPeer() functions.
 func NewClient(p wamp.Peer, cfg ClientConfig, logger stdlog.StdLog) (*Client, error) {
 	if cfg.ResponseTimeout == 0 {
 		cfg.ResponseTimeout = defaultResponseTimeout

--- a/client/rawsocket.go
+++ b/client/rawsocket.go
@@ -1,0 +1,19 @@
+package client
+
+import (
+	"github.com/gammazero/nexus/stdlog"
+	"github.com/gammazero/nexus/transport"
+	"github.com/gammazero/nexus/transport/serialize"
+)
+
+// NewRawSocketClient creates a new rawsocket client connected to the specified
+// address and using the specified serialization.
+//
+// JoinRealm must be called before other client functions.
+func NewRawSocketClient(network, address string, serialization serialize.Serialization, cfg ClientConfig, logger stdlog.StdLog, recvLimit int) (*Client, error) {
+	p, err := transport.ConnectRawSocketPeer(network, address, serialization, logger, recvLimit)
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(p, cfg, logger)
+}

--- a/rawsocketserver.go
+++ b/rawsocketserver.go
@@ -1,0 +1,95 @@
+package nexus
+
+import (
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/gammazero/nexus/stdlog"
+	"github.com/gammazero/nexus/transport"
+	"github.com/gammazero/nexus/transport/serialize"
+)
+
+// RawSocketServer handles socket connections.
+type RawSocketServer struct {
+	Router
+
+	listener net.Listener
+	addr     net.Addr
+
+	serializer serialize.Serializer
+	log        stdlog.StdLog
+	recvLimit  int
+	stop       chan os.Signal
+}
+
+// NewRawSocketServer takes a router instance and creates a new socket server.
+func NewRawSocketServer(r Router, network, address string, recvLimit int) (*RawSocketServer, error) {
+	s := &RawSocketServer{
+		Router:    r,
+		log:       r.Logger(),
+		recvLimit: recvLimit,
+		stop:      make(chan os.Signal, 1),
+	}
+	signal.Notify(s.stop, syscall.SIGINT)
+
+	l, err := net.Listen(network, address)
+	if err != nil {
+		s.log.Print(err)
+		return nil, err
+	}
+	s.listener = l
+	if tcpListener, ok := l.(*net.TCPListener); ok {
+		s.addr = tcpListener.Addr()
+	} else if unixListener, ok := l.(*net.UnixListener); ok {
+		s.addr = unixListener.Addr()
+	}
+
+	return s, nil
+}
+
+// Serve continues to accept new client connections until the server is closed.
+func (s *RawSocketServer) Serve(keepalive bool) {
+	go func(listener net.Listener) {
+		<-s.stop
+		listener.Close()
+	}(s.listener)
+
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			s.listener.Close()
+			return
+		}
+		if tcpConn, ok := conn.(*net.TCPConn); ok && keepalive {
+			tcpConn.SetKeepAlive(true)
+			tcpConn.SetKeepAlivePeriod(3 * time.Minute)
+		}
+
+		go s.handleRawSocket(conn)
+	}
+}
+
+// Close stops the server from accepting connections, and causes Serve to exit.
+func (s *RawSocketServer) Close() {
+	s.stop <- nil
+}
+
+// Addr returns the net.Addr that the server is listening on.
+func (s *RawSocketServer) Addr() net.Addr {
+	return s.addr
+}
+
+func (s *RawSocketServer) handleRawSocket(conn net.Conn) {
+	peer, err := transport.AcceptRawSocket(conn, s.log, s.recvLimit)
+	if err != nil {
+		s.log.Println("Error accepting rawsocket client:", err)
+		return
+	}
+
+	if err := s.Router.Attach(peer); err != nil {
+		s.log.Println("Error attaching to router:", err)
+	}
+}

--- a/rawsocketserver_test.go
+++ b/rawsocketserver_test.go
@@ -1,0 +1,75 @@
+package nexus
+
+import (
+	"testing"
+
+	"github.com/fortytw2/leaktest"
+	"github.com/gammazero/nexus/stdlog"
+	"github.com/gammazero/nexus/transport"
+	"github.com/gammazero/nexus/transport/serialize"
+	"github.com/gammazero/nexus/wamp"
+)
+
+func newTestRawSocketServer(t *testing.T) (*RawSocketServer, stdlog.StdLog) {
+	r, err := NewRouter(routerConfig, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := NewRawSocketServer(r, "tcp", ":8181", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		s.Serve(false)
+		r.Close()
+	}()
+
+	return s, r.Logger()
+}
+
+func TestRSHandshakeJSON(t *testing.T) {
+	defer leaktest.Check(t)()
+	s, lgr := newTestRawSocketServer(t)
+	defer s.Close()
+
+	client, err := transport.ConnectRawSocketPeer(s.Addr().Network(),
+		s.Addr().String(), serialize.JSON, lgr, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client.Send(&wamp.Hello{Realm: testRealm, Details: clientRoles})
+	msg, ok := <-client.Recv()
+	if !ok {
+		t.Fatal("recv chan closed")
+	}
+
+	if _, ok = msg.(*wamp.Welcome); !ok {
+		t.Fatal("expected WELCOME, got", msg.MessageType())
+	}
+	client.Close()
+}
+
+func TestRSHandshakeMsgpack(t *testing.T) {
+	defer leaktest.Check(t)()
+	s, lgr := newTestRawSocketServer(t)
+	defer s.Close()
+
+	client, err := transport.ConnectRawSocketPeer(s.Addr().Network(),
+		s.Addr().String(), serialize.MSGPACK, lgr, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client.Send(&wamp.Hello{Realm: testRealm, Details: clientRoles})
+	msg, ok := <-client.Recv()
+	if !ok {
+		t.Fatal("Receive buffer closed")
+	}
+
+	if _, ok = msg.(*wamp.Welcome); !ok {
+		t.Fatalf("expected WELCOME, got %s: %+v", msg.MessageType(), msg)
+	}
+	client.Close()
+}

--- a/transport/rawsocketpeer.go
+++ b/transport/rawsocketpeer.go
@@ -1,0 +1,407 @@
+package transport
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"time"
+
+	"github.com/gammazero/nexus/stdlog"
+	"github.com/gammazero/nexus/transport/serialize"
+	"github.com/gammazero/nexus/wamp"
+)
+
+// rawSocketPeer implements the Peer interface, connecting the Send and Recv
+// methods to a socket.
+type rawSocketPeer struct {
+	conn       net.Conn
+	serializer serialize.Serializer
+	sendLimit  int
+	recvLimit  int
+
+	// Used to signal the socket is closed explicitly.
+	closed chan struct{}
+
+	// Channels communicate with router.
+	rd chan wamp.Message
+	wr chan wamp.Message
+
+	writerDone chan struct{}
+
+	log stdlog.StdLog
+}
+
+const (
+	// Serializers
+	rawsocketJSON    = 1
+	rawsocketMsgpack = 2
+
+	// RawSocket header ID.
+	magic = 0x7f
+)
+
+// ConnectRawSocketPeer creates a new rawSocketPeer with the specified config,
+// and connects it to the WAMP router at the specified address.  The network
+// and address parameters are documented here:
+// https://golang.org/pkg/net/#Dial
+//
+// If recvLimit is > 0, then the client will not receive messages with size
+// larger than the nearest power of 2 greater than or equal to recvLimit.  If
+// recvLimit is <= 0, then the default of 16M is used.
+func ConnectRawSocketPeer(network, address string, serialization serialize.Serialization, logger stdlog.StdLog, recvLimit int) (wamp.Peer, error) {
+	var protocol byte
+	switch serialization {
+	case serialize.MSGPACK:
+		protocol = rawsocketMsgpack
+	case serialize.JSON:
+		protocol = rawsocketJSON
+	default:
+		return nil, errors.New("serialization not supported by rawsocket")
+	}
+
+	conn, err := net.Dial(network, address)
+	if err != nil {
+		return nil, err
+	}
+
+	peer, err := clientHandshake(conn, logger, protocol, recvLimit)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return peer, nil
+}
+
+// AcceptRawSocket handles the client handshake and returns
+//
+// If recvLimit is > 0, then the client will not receive messages with size
+// larger than the nearest power of 2 greater than or equal to recvLimit.  If
+// recvLimit is <= 0, then the default of 16M is used.
+func AcceptRawSocket(conn net.Conn, logger stdlog.StdLog, recvLimit int) (wamp.Peer, error) {
+	peer, err := serverHandshake(conn, logger, recvLimit)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return peer, nil
+}
+
+// newRawSocketPeer creates a rawsocket peer from an existing socket
+// connection.  This is used for handling clients connecting to the WAMP
+// router.
+func newRawSocketPeer(conn net.Conn, serializer serialize.Serializer, logger stdlog.StdLog, sendLimit, recvLimit int) *rawSocketPeer {
+	rs := &rawSocketPeer{
+		conn:       conn,
+		serializer: serializer,
+		sendLimit:  sendLimit,
+		recvLimit:  recvLimit,
+
+		closed:     make(chan struct{}),
+		writerDone: make(chan struct{}),
+
+		// The router will read from this channel and immediately dispatch the
+		// message to the broker or dealer.  Therefore this channel can be
+		// unbuffered.
+		rd: make(chan wamp.Message),
+
+		// The channel for messages being written to the socket should be
+		// large enough to prevent blocking while waiting for a slow socket
+		// to send messages.  For this reason it may be necessary for these
+		// messages to be put into an outbound queue that can grow.
+		wr: make(chan wamp.Message, outQueueSize),
+
+		log: logger,
+	}
+	// Sending to and receiving from socket is handled concurrently.
+	go rs.recvHandler()
+	go rs.sendHandler()
+
+	return rs
+}
+
+func (rs *rawSocketPeer) Recv() <-chan wamp.Message { return rs.rd }
+
+func (rs *rawSocketPeer) Send(msg wamp.Message) error {
+	select {
+	case rs.wr <- msg:
+	default:
+		err := fmt.Errorf("client blocked - dropped %s", msg.MessageType())
+		rs.log.Println("!!!", err)
+		return err
+	}
+	return nil
+}
+
+// Close closes the rawsocket peer.  This closes the local send channel, and
+// sends a close control message to the socket to tell the other side to
+// close.
+//
+// *** Do not call Send after calling Close. ***
+func (rs *rawSocketPeer) Close() {
+	// Tell sendHandler to exit, allowing it to finish sending any queued
+	// messages.  Do not close wr channel in case there are incoming messages
+	// during close.
+	rs.wr <- nil
+	<-rs.writerDone
+
+	// Tell recvHandler to close.
+	close(rs.closed)
+
+	// Ignore errors since socket may have been closed by other side first in
+	// response to a goodbye message.
+	rs.conn.Close()
+}
+
+// sendHandler pulls messages from the write channel, and pushes them to the
+// socket.
+func (rs *rawSocketPeer) sendHandler() {
+	defer close(rs.writerDone)
+	for msg := range rs.wr {
+		if msg == nil {
+			return
+		}
+		b, err := rs.serializer.Serialize(msg)
+		if err != nil {
+			rs.log.Print(err)
+		}
+		if len(b) > rs.sendLimit {
+			rs.log.Println("Message size", len(b), "exceeds limit of",
+				rs.sendLimit)
+			continue
+		}
+		lenBytes := intToBytes(len(b))
+		header := []byte{0x0, lenBytes[0], lenBytes[1], lenBytes[2]}
+		if _, err = rs.conn.Write(header); err != nil {
+			rs.log.Println("Error writing header:", err)
+			continue
+		}
+		if _, err = rs.conn.Write(b); err != nil {
+			rs.log.Println("Error writing message:", err)
+			continue
+		}
+	}
+}
+
+// recvHandler pulls messages from the socket and pushes them to the read
+// channel.
+func (rs *rawSocketPeer) recvHandler() {
+	// When done, close read channel to cause router to remove session if not
+	// already removed.
+	defer close(rs.rd)
+MsgLoop:
+	for {
+		var header [4]byte
+		_, err := io.ReadFull(rs.conn, header[:])
+		if err != nil {
+			select {
+			case <-rs.closed:
+				// Peer was closed explicitly. sendHandler should have already
+				// been told to exit.
+			default:
+				// Peer received control message to close.  Cause sendHandler
+				// to exit without closing the write channel (in case writes
+				// still happening) and allow it to finish sending any queued
+				// messages.
+				rs.wr <- nil
+				<-rs.writerDone
+
+				// Close socket connection.
+				rs.conn.Close()
+			}
+			return
+		}
+
+		length := bytesToInt(header[1:])
+		if length > rs.recvLimit {
+			rs.log.Print("Received message that exceeded size limit, closing")
+			rs.conn.Close()
+			break
+		}
+
+		var msg wamp.Message
+		switch header[0] & 0x07 {
+		case 0: // WAMP message
+			buf := make([]byte, length)
+			_, err = io.ReadFull(rs.conn, buf)
+			if err != nil {
+				rs.log.Println("Error reading message:", err)
+				rs.Close()
+				return
+			}
+			msg, err = rs.serializer.Deserialize(buf)
+			if err != nil {
+				// TODO: something more than merely logging?
+				rs.log.Println("Cannot deserialize peer message:", err)
+				continue MsgLoop
+			}
+		case 1: // PING
+			header[0] = 0x02
+			if _, err = rs.conn.Write(header[:]); err != nil {
+				rs.log.Println("Error writing header responding to PING:", err)
+				rs.conn.Close()
+				return
+			}
+			if _, err = io.CopyN(rs.conn, rs.conn, int64(length)); err != nil {
+				rs.log.Println("Error responding to PING:", err)
+				rs.conn.Close()
+				return
+			}
+			continue MsgLoop
+		case 2: // PONG
+			_, err = io.CopyN(ioutil.Discard, rs.conn, int64(length))
+			if err != nil {
+				rs.log.Println("Error reading PONG:", err)
+				rs.conn.Close()
+				return
+			}
+			continue MsgLoop
+		}
+
+		// It is OK for the router to block a client since routing should be
+		// very quick compared to the time to transfer a message over the
+		// socket, and a blocked client will not block other clients.
+		//
+		// Need to wake up on rs.closed so this goroutine can exit in the case
+		// that messages are not being read from the peer and prevent this
+		// write from completing.
+		select {
+		case rs.rd <- msg:
+		case <-rs.closed:
+			// If closed, try for one second to send the last message and then
+			// exit recvHandler.
+			select {
+			case rs.rd <- msg:
+			case <-time.After(time.Second):
+				rs.conn.Close()
+				return
+			}
+		}
+	}
+}
+
+func clientHandshake(conn net.Conn, logger stdlog.StdLog, protocol byte, recvLimit int) (*rawSocketPeer, error) {
+	maxRecvLen := fitRecvLimit(recvLimit)
+
+	_, err := conn.Write([]byte{magic, (maxRecvLen&0xf)<<4 | protocol, 0, 0})
+	if err != nil {
+		return nil, fmt.Errorf("error sending handshake: %s", err)
+	}
+
+	var buf [4]byte
+	if _, err = io.ReadFull(conn, buf[:]); err != nil {
+		return nil, err
+	}
+
+	if buf[0] != magic {
+		return nil, errors.New("not a rawsocket handshake")
+	}
+
+	repSerializer := buf[1] & 0xf
+	if repSerializer == 0 {
+		errCode := buf[1] >> 4
+		switch errCode {
+		case 0:
+			return nil, errors.New("illegal error code")
+		case 1:
+			return nil, errors.New("serializer unsupported")
+		case 2:
+			return nil, errors.New("maximum message length unacceptable")
+		case 3:
+			return nil, errors.New("use of reserved bits (unsupported feature)")
+		case 4:
+			return nil, errors.New("maximum connection count reached")
+		default:
+			return nil, fmt.Errorf("unknown error: %d", errCode)
+		}
+	}
+
+	if repSerializer != protocol {
+		return nil, errors.New("serializer mismatch")
+	}
+
+	var serializer serialize.Serializer
+	switch protocol {
+	case rawsocketJSON:
+		serializer = &serialize.JSONSerializer{}
+	case rawsocketMsgpack:
+		serializer = &serialize.MessagePackSerializer{}
+	}
+
+	sendLimit := byteToLength(buf[1] >> 4)
+	recvLimit = byteToLength(maxRecvLen)
+	return newRawSocketPeer(conn, serializer, logger, sendLimit, recvLimit), nil
+}
+
+func serverHandshake(conn net.Conn, logger stdlog.StdLog, recvLimit int) (*rawSocketPeer, error) {
+	var buf [4]byte
+	if _, err := io.ReadFull(conn, buf[:]); err != nil {
+		return nil, err
+	}
+
+	if buf[0] != magic {
+		return nil, errors.New("not a rawsocket handshake")
+	}
+	if buf[2] != 0 || buf[3] != 0 {
+		conn.Write([]byte{magic, byte(0x3 << 4), 0, 0})
+		return nil, errors.New("use of reserved bits (unsupported feature)")
+	}
+
+	serialization := buf[1] & 0xf
+	var serializer serialize.Serializer
+	switch serialization {
+	case 0:
+		return nil, errors.New("illegal serializer value")
+	case rawsocketJSON:
+		serializer = &serialize.JSONSerializer{}
+	case rawsocketMsgpack:
+		serializer = &serialize.MessagePackSerializer{}
+	default:
+		conn.Write([]byte{magic, byte(0x1 << 4), 0, 0})
+		return nil, errors.New("serializer unsupported")
+	}
+
+	maxRecvLen := fitRecvLimit(recvLimit)
+
+	_, err := conn.Write([]byte{magic, maxRecvLen<<4 | serialization, 0, 0})
+	if err != nil {
+		return nil, fmt.Errorf("error sending handshake: %s", err)
+	}
+
+	sendLimit := byteToLength(buf[1] >> 4)
+	recvLimit = byteToLength(maxRecvLen)
+	return newRawSocketPeer(conn, serializer, logger, sendLimit, recvLimit), nil
+}
+
+func fitRecvLimit(recvLimit int) byte {
+	if recvLimit > 0 {
+		for b := byte(0); b < 0xf; b++ {
+			if byteToLength(b) >= recvLimit {
+				return b
+			}
+		}
+	}
+	return 0xf
+}
+
+func intToBytes(i int) [3]byte {
+	return [3]byte{
+		byte((i >> 16) & 0xff),
+		byte((i >> 8) & 0xff),
+		byte(i & 0xff),
+	}
+}
+
+func bytesToInt(b []byte) int {
+	var n, shift uint
+	for i := len(b) - 1; i >= 0; i-- {
+		n |= uint(b[i]) << shift
+		shift += 8
+	}
+	return int(n)
+}
+
+func byteToLength(b byte) int {
+	return int(1 << (b + 9))
+}


### PR DESCRIPTION
Implement RawSocket transport.

- Add option to run AATs with Unix or TCP rawsocket.
- When creating a rawsocket client or server, optionally specify maximum message size to receive.