### PR TITLE
Correctly set "progress" flag on call result.  Fixes #52.

### DIFF
--- a/dealer_test.go
+++ b/dealer_test.go
@@ -205,6 +205,9 @@ func TestBasicCall(t *testing.T) {
 	if rslt.Request != 125 {
 		t.Fatal("wrong request ID in RESULT")
 	}
+	if wamp.OptionFlag(rslt.Details, "progress") {
+		t.Fatal("progress flag should not be set for response")
+	}
 
 	// Test calling valid procedure, with callee responding with error.
 	dealer.Call(callerSession,

--- a/router.go
+++ b/router.go
@@ -106,8 +106,9 @@ func (r *router) Logger() stdlog.StdLog { return r.log }
 func (r *router) Attach(client wamp.Peer) error {
 	sendAbort := func(reason wamp.URI, abortErr error) {
 		abortMsg := wamp.Abort{Reason: reason}
+		abortMsg.Details = wamp.Dict{}
 		if abortErr != nil {
-			abortMsg.Details = wamp.Dict{"error": abortErr.Error()}
+			abortMsg.Details["error"] = abortErr.Error()
 			r.log.Println("Aborting client connection:", abortErr)
 		}
 		client.Send(&abortMsg)


### PR DESCRIPTION
This also fixes interoperability problem with ABORT message having nil Details.