### PR TITLE
Provide function to sign challenge using PBKDF2

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -718,8 +718,8 @@ func (c *Client) Close() error {
 }
 
 // joinRealm joins a WAMP realm, handling challenge/response authentication if
-// needed.  The authHandlers argument supplies a map of WAMP authmethod names
-// to functions that handle each auth type.  This can be nil if router is
+// needed.  The authHandlers portion of cfg supplies a map of WAMP authmethod
+// names to functions that handle each auth type.  This can be nil if router is
 // expected to allow anonymous authentication.
 func joinRealm(peer wamp.Peer, cfg ClientConfig) (*wamp.Welcome, error) {
 	if cfg.Realm == "" {

--- a/router/auth/authenticator.go
+++ b/router/auth/authenticator.go
@@ -35,7 +35,7 @@ type KeyStore interface {
 
 	// PasswordInfo returns salting info for the user's password.  This
 	// information must be available when using keys computed with PBKDF2.
-	PasswordInfo(authid string) (string, int, int)
+	PasswordInfo(authid string) (salt string, keylen int, iterations int)
 
 	// Returns the authrole for the user.
 	AuthRole(authid string) (string, error)

--- a/router/auth/authenticator.go
+++ b/router/auth/authenticator.go
@@ -33,7 +33,8 @@ type KeyStore interface {
 	// AuthKey returns the user's key appropriate for the specified authmethod.
 	AuthKey(authid, authmethod string) ([]byte, error)
 
-	// PasswordInfo returns salting info for the user's password.
+	// PasswordInfo returns salting info for the user's password.  This
+	// information must be available when using keys computed with PBKDF2.
 	PasswordInfo(authid string) (string, int, int)
 
 	// Returns the authrole for the user.

--- a/router/auth/crauth.go
+++ b/router/auth/crauth.go
@@ -58,6 +58,7 @@ func (cr *CRAuthenticator) Authenticate(sid wamp.ID, details wamp.Dict, client w
 	}
 
 	extra := wamp.Dict{"challenge": chStr}
+	// If key was created using PBKDF2, then salting info should be present.
 	salt, keylen, iters := cr.keyStore.PasswordInfo(authid)
 	if salt != "" {
 		extra["salt"] = salt

--- a/router/auth/crauth_test.go
+++ b/router/auth/crauth_test.go
@@ -67,7 +67,7 @@ func cliRsp(p wamp.Peer) {
 func clientAuthFunc(c *wamp.Challenge) (string, wamp.Dict) {
 	// If the client needed to lookup a user's key, this would require decoding
 	// the JSON-encoded ch string and getting the authid. For this example
-	// assume that client only operate as one user and knows the key to use.
+	// assume that client only operates as one user and knows the key to use.
 	var sig string
 	switch c.AuthMethod {
 	case "ticket":

--- a/vendor/golang.org/x/crypto/LICENSE
+++ b/vendor/golang.org/x/crypto/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/crypto/PATENTS
+++ b/vendor/golang.org/x/crypto/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/crypto/pbkdf2/pbkdf2.go
+++ b/vendor/golang.org/x/crypto/pbkdf2/pbkdf2.go
@@ -1,0 +1,77 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+Package pbkdf2 implements the key derivation function PBKDF2 as defined in RFC
+2898 / PKCS #5 v2.0.
+
+A key derivation function is useful when encrypting data based on a password
+or any other not-fully-random data. It uses a pseudorandom function to derive
+a secure encryption key based on the password.
+
+While v2.0 of the standard defines only one pseudorandom function to use,
+HMAC-SHA1, the drafted v2.1 specification allows use of all five FIPS Approved
+Hash Functions SHA-1, SHA-224, SHA-256, SHA-384 and SHA-512 for HMAC. To
+choose, you can pass the `New` functions from the different SHA packages to
+pbkdf2.Key.
+*/
+package pbkdf2 // import "golang.org/x/crypto/pbkdf2"
+
+import (
+	"crypto/hmac"
+	"hash"
+)
+
+// Key derives a key from the password, salt and iteration count, returning a
+// []byte of length keylen that can be used as cryptographic key. The key is
+// derived based on the method described as PBKDF2 with the HMAC variant using
+// the supplied hash function.
+//
+// For example, to use a HMAC-SHA-1 based PBKDF2 key derivation function, you
+// can get a derived key for e.g. AES-256 (which needs a 32-byte key) by
+// doing:
+//
+// 	dk := pbkdf2.Key([]byte("some password"), salt, 4096, 32, sha1.New)
+//
+// Remember to get a good random salt. At least 8 bytes is recommended by the
+// RFC.
+//
+// Using a higher iteration count will increase the cost of an exhaustive
+// search but will also make derivation proportionally slower.
+func Key(password, salt []byte, iter, keyLen int, h func() hash.Hash) []byte {
+	prf := hmac.New(h, password)
+	hashLen := prf.Size()
+	numBlocks := (keyLen + hashLen - 1) / hashLen
+
+	var buf [4]byte
+	dk := make([]byte, 0, numBlocks*hashLen)
+	U := make([]byte, hashLen)
+	for block := 1; block <= numBlocks; block++ {
+		// N.B.: || means concatenation, ^ means XOR
+		// for each block T_i = U_1 ^ U_2 ^ ... ^ U_iter
+		// U_1 = PRF(password, salt || uint(i))
+		prf.Reset()
+		prf.Write(salt)
+		buf[0] = byte(block >> 24)
+		buf[1] = byte(block >> 16)
+		buf[2] = byte(block >> 8)
+		buf[3] = byte(block)
+		prf.Write(buf[:4])
+		dk = prf.Sum(dk)
+		T := dk[len(dk)-hashLen:]
+		copy(U, T)
+
+		// U_n = PRF(password, U_(n-1))
+		for n := 2; n <= iter; n++ {
+			prf.Reset()
+			prf.Write(U)
+			U = U[:0]
+			U = prf.Sum(U)
+			for x := range U {
+				T[x] ^= U[x]
+			}
+		}
+	}
+	return dk[:keyLen]
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -13,6 +13,12 @@
 			"path": "github.com/ugorji/go/codec",
 			"revision": "8c0409fcbb70099c748d71f714529204975f6c3f",
 			"revisionTime": "2017-08-26T15:59:43Z"
+		},
+		{
+			"checksumSHA1": "1MGpGDQqnUoRpv7VEcQrXOBydXE=",
+			"path": "golang.org/x/crypto/pbkdf2",
+			"revision": "94eea52f7b742c7cbe0b03b22f0c4c8631ece122",
+			"revisionTime": "2017-11-28T01:43:40Z"
 		}
 	],
 	"rootPath": "github.com/gammazero/nexus"

--- a/wamp/crsign/crsign.go
+++ b/wamp/crsign/crsign.go
@@ -6,12 +6,81 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
+	"hash"
+
+	"github.com/gammazero/nexus/wamp"
+	"golang.org/x/crypto/pbkdf2"
 )
 
-// SignChallenge computes the HMAC-SHA256 over the challenge string, and
-// returns the result as a base64-encoded string.
+// SignChallenge computes the HMAC-SHA256, using the given key, over the
+// challenge string, and returns the result as a base64-encoded string.
 func SignChallenge(ch string, key []byte) string {
 	sig := hmac.New(sha256.New, key)
 	sig.Write([]byte(ch))
 	return base64.StdEncoding.EncodeToString(sig.Sum(nil))
+}
+
+// Default parameters for PBKDF2.  These are used if not present in CHALLENGE.
+const (
+	defaultIters  = 1000
+	defaultKeyLen = 32
+)
+
+// RespondChallenge is used by clients to sign the challenge string contained
+// in the CHALLENGE message using the given password.  If the CHALLENGE message
+// contains salting information, then a derived key is computed using PBKDF2,
+// and that derived key is used to sign the challenge string.  If there is no
+// salt, then no derived key is computed and the raw password is used to sign
+// the challenge.
+//
+// Set h to nil to use default hash sha256.  This is provided in case the
+// server-side PBKDF2 uses a different hash algorithm.
+//
+// Example Client Use:
+//
+//     func clientCRAuthFunc(c *wamp.Challenge) (string, wamp.Dict) {
+//         // Get user password and return signature.
+//         password := AskUserPassoword()
+//         return RespondChallenge(password, c, nil), wamp.Dict{}
+//     }
+//
+//     // Configure and create new client.
+//     cfg := client.ClientConfig{
+//         ...
+//         AuthHandlers: map[string]client.AuthFunc{
+//             "wampcra": clientCRAuthFunc,
+//         },
+//     }
+//     cli, err = client.ConnectNet(routerAddr, cfg)
+//
+func RespondChallenge(pass string, c *wamp.Challenge, h func() hash.Hash) string {
+	ch := wamp.OptionString(c.Extra, "challenge")
+	// If the client needed to lookup a user's key, this would require decoding
+	// the JSON-encoded challenge string and getting the authid.  For this
+	// example assume that client only operates as one user and knows the key
+	// to use.
+	saltStr := wamp.OptionString(c.Extra, "salt")
+	// If no salt given, use raw password as key.
+	if saltStr == "" {
+		return SignChallenge(ch, []byte(pass))
+	}
+
+	// If salting info give, then compute a derived key using PBKDF2.
+	salt := []byte(saltStr)
+	iters := int(wamp.OptionInt64(c.Extra, "iterations"))
+	keylen := int(wamp.OptionInt64(c.Extra, "keylen"))
+
+	if iters == 0 {
+		iters = defaultIters
+	}
+	if keylen == 0 {
+		keylen = defaultKeyLen
+	}
+	if h == nil {
+		h = sha256.New
+	}
+	// Compute derived key.
+	dk := pbkdf2.Key([]byte(pass), salt, iters, keylen, h)
+	// Sign challenge using derived key.
+	return SignChallenge(ch, dk)
 }

--- a/wamp/crsign/crsign_test.go
+++ b/wamp/crsign/crsign_test.go
@@ -1,12 +1,54 @@
 package crsign
 
-import "testing"
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/gammazero/nexus/wamp"
+	"golang.org/x/crypto/pbkdf2"
+)
+
+var chStr = "{ \"nonce\":\"LHRTC9zeOIrt_9U3\", \"authprovider\":\"userdb\", \"authid\":\"peter\", \"timestamp\":\"2014-06-22T16:36:25.448Z\", \"authrole\":\"user\", \"authmethod\":\"wampcra\", \"session\":3251278072152162 }"
 
 func TestCRSign(t *testing.T) {
-	chStr := "{ \"nonce\":\"LHRTC9zeOIrt_9U3\", \"authprovider\":\"userdb\", \"authid\":\"peter\", \"timestamp\":\"2014-06-22T16:36:25.448Z\", \"authrole\":\"user\", \"authmethod\":\"wampcra\", \"session\":3251278072152162 }"
-
 	sig := SignChallenge(chStr, []byte("secret"))
 	if sig != "NWktSrMd4ItBSAKYEwvu1bTY7G/sSyjKbz+pNP9c04A=" {
-		t.Fatal("wrong signature")
+		t.Fatal("Wrong signature")
+	}
+}
+
+func TestRespondChallenge(t *testing.T) {
+	salt := []byte("salt123")
+	pass := "password"
+
+	// Compute derived key.  Normally this would normally be precomputed and
+	// the router would read it and the salting from from storage.
+	dk := pbkdf2.Key([]byte(pass), salt, defaultIters, defaultKeyLen, sha256.New)
+
+	// Server creates CHALLENGE message containing challenge string and salting
+	// info that was used to create derived key.
+	extra := wamp.Dict{"challenge": chStr}
+	extra["salt"] = salt
+	extra["keylen"] = defaultKeyLen
+	extra["iterations"] = defaultIters
+	chMsg := &wamp.Challenge{
+		AuthMethod: "wampcra",
+		Extra:      extra,
+	}
+
+	// Client computes derived key from password and salting info, then signes
+	// challenge using derived key.  Response gets sent back to router.
+	sigClient := RespondChallenge(pass, chMsg, nil)
+
+	// Router computes its own signature for the challenge and compares it with
+	// the client's.Sign challenge using derived key.
+	sigServer := SignChallenge(chStr, dk)
+	if sigClient != sigServer {
+		t.Fatal("Client and server signatures do not match")
+	}
+
+	// Check that signature was what was expected.
+	if sigServer != "qczWyhq0mAtfNeqPCxorzlcz0t4jns97XBUHoTu2Brs=" {
+		t.Fatal("Wrong signature:", sigServer)
 	}
 }


### PR DESCRIPTION
This makes it very easy to write your client's CR auth function.  If can be as simple as this:
```go
func clientCRAuthFunc(c *wamp.Challenge) (string, wamp.Dict) {
    // Get user password and return signature.
    password := AskUserPassoword()
    return RespondChallenge(password, c, nil), wamp.Dict{}
}
```
Then you can supply that as the `wampcra` auth handler when creating your client:
```go
cfg := client.ClientConfig{
    ...
    AuthHandlers: map[string]client.AuthFunc{
        "wampcra": clientCRAuthFunc,
    },
}
cli, err = client.ConnectNet(routerAddr, cfg)
```

This PR addresses issue #66 