### PR TITLE
Pass ResponseWriter.Header() to Upgrader

### DIFF
--- a/router/websocketserver.go
+++ b/router/websocketserver.go
@@ -132,7 +132,7 @@ func (s *WebsocketServer) ListenAndServeTLS(address string, tlscfg *tls.Config, 
 
 // ServeHTTP handles HTTP connections.
 func (s *WebsocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	conn, err := s.Upgrader.Upgrade(w, r, nil)
+	conn, err := s.Upgrader.Upgrade(w, r, w.Header())
 	if err != nil {
 		s.log.Println("Error upgrading to websocket connection:", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)


### PR DESCRIPTION
This simple change would allow passing HTTP headers for WS Upgrade request, like so:

```
// ...

middleware := func(next http.Handler) http.Handler {
	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		cookie := &http.Cookie{Name: "sample", Value: "sample"}
		http.SetCookie(w, cookie)
		next.ServeHTTP(w, r)
	})
}
server := &http.Server{
	Handler: middleware(router.NewWebsocketServer(nexusRouter)),
	Addr: "ws-address"
}

// ...
```