### PR TITLE
Cookieauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Nexus is a software package that provides a WAMP router library, client library,
 
 - **Concurrent Asynchronous I/O** Nexus supports large numbers of clients concurrently sending and receiving messages, and never blocks on I/O, even if a client becomes unresponsive.  See [Router Concurrency](https://github.com/gammazero/nexus/wiki/Router-Concurrency) for details.
 - **WAMP Advanced Profile Features**  This project implements most of the advanced profile features in WAMP v2.  See [current feature support](https://github.com/gammazero/nexus#advanced-profile-feature-support) provided by nexus.  Nexus also offers extended functionality for retrieving session information and for message filtering, giving clients more ability to decide where to send messages.
-- **Flexibility** Multiple transports and serialization options are supported, and more are being developed to maximize interoperability.  Currently nexus provides websocket, rawsocket, and local (in-process) transports.  [JSON](https://en.wikipedia.org/wiki/JSON) and [MessagePack](http://msgpack.org/index.html) serialization is available over websockets and rawsockets.
+- **Flexibility** Multiple transports and serialization options are supported, and more are being developed to maximize interoperability.  Currently nexus provides websocket, rawsocket (tcp and unix), and local (in-process) transports.  [JSON](https://en.wikipedia.org/wiki/JSON) and [MessagePack](http://msgpack.org/index.html) serialization is available over websockets and rawsockets.
 - **Security** TLS is available over websockets and rawsockets with client and server APIs that allow configuration of TLS.  The nexus router library also provides interfaces for integration of client authentication and authorization logic.
 
 ## Quick Start
@@ -66,12 +66,12 @@ A stable release of nexus is available with support for most advanced profile fe
 
 These features listed here are being added.  If there are are specific items needed, or if any changes in current functionality are needed, then please open an [issue](https://github.com/gammazero/nexus/issues).
 
-- stress tests and benchmarks
-- more documentation (in progress)
-- advanced profile examples (in progress)
-- [CBOR](https://tools.ietf.org/html/rfc7049) Serialization (planned)
+- more stress tests and benchmarks
+- more documentation
+- more advanced profile examples
 - testament_meta_api
 - event history
+- [CBOR](https://tools.ietf.org/html/rfc7049) Serialization
 - call trust levels
 - publisher trust levels
 
@@ -113,7 +113,7 @@ These features listed here are being added.  If there are are specific items nee
 | Feature | Supported |
 | ------- | --------- |
 | challenge-response authentication | Yes | 
-| cookie authentication | No |
+| cookie authentication | Yes |
 | ticket authentication | Yes |
 | rawsocket transport | Yes |
 | batched WS transport | No |

--- a/client/network.go
+++ b/client/network.go
@@ -62,3 +62,26 @@ func ConnectNet(routerURL string, cfg ClientConfig) (*Client, error) {
 	}
 	return NewClient(p, cfg)
 }
+
+// CookieURL takes a websocket URL string and outputs a url.URL that can be
+// used to retrieve cookies from a http.CookieJar as may be provided in
+// ClientConfig.WsCfg.Jar.
+func CookieURL(routerURL string) (*url.URL, error) {
+	u, err := url.Parse(routerURL)
+	if err != nil {
+		return nil, err
+	}
+
+	switch u.Scheme {
+	case "ws":
+		u.Scheme = "http"
+	case "wss":
+		u.Scheme = "https"
+	case "http", "https":
+		// Ok already; do nothing
+	default:
+		return nil, fmt.Errorf("scheme not valid for websocket: %s", u.Scheme)
+	}
+
+	return u, nil
+}

--- a/examples/newclient/newclient.go
+++ b/examples/newclient/newclient.go
@@ -112,6 +112,7 @@ func NewClient(logger *log.Logger) (*client.Client, error) {
 	if compress {
 		cfg.WsCfg.EnableCompression = true
 	}
+	cfg.WsCfg.EnableTrackingCookie = true
 
 	// Create client with requested transport type.
 	var cli *client.Client

--- a/examples/server/server.go
+++ b/examples/server/server.go
@@ -47,7 +47,10 @@ func main() {
 	// Create websocket and rawsocket servers.  Websocket comopression enabled,
 	// will be used if clients request it.
 	wss := router.NewWebsocketServer(nxr)
-	wss.SetConfig(transport.WebsocketConfig{EnableCompression: true})
+	wss.SetConfig(transport.WebsocketConfig{
+		EnableCompression:    true,
+		EnableTrackingCookie: true,
+	})
 	rss := router.NewRawSocketServer(nxr, 0, 0)
 
 	// ---- Start servers ----

--- a/nexusd/config.go
+++ b/nexusd/config.go
@@ -23,6 +23,8 @@ type Config struct {
 		CompressionLevel      int  `json:"compression_level"`
 		// Enable sending cookie to identify client in later connections.
 		EnableTrackingCookie bool `json:"enable_tracking_cookie"`
+		// Enable reading HTTP header from client requests.
+		EnableRequestCapture bool `json:"enable_request_capture"`
 	}
 
 	// RawSocket configuration parameters.

--- a/nexusd/config.go
+++ b/nexusd/config.go
@@ -21,6 +21,8 @@ type Config struct {
 		EnableCompression     bool `json:"enable_compression"`
 		EnableContextTakeover bool `json:"enable_context_takeover"`
 		CompressionLevel      int  `json:"compression_level"`
+		// Enable sending cookie to identify client in later connections.
+		EnableTrackingCookie bool `json:"enable_tracking_cookie"`
 	}
 
 	// RawSocket configuration parameters.

--- a/nexusd/main.go
+++ b/nexusd/main.go
@@ -69,8 +69,12 @@ func main() {
 				wsCfg.CompressionLevel = conf.WebSocket.CompressionLevel
 			}
 			if conf.WebSocket.EnableTrackingCookie {
-				logger.Printf("Cookie tracking enabled")
-				wsCfg.EnableTrackingCookie = true
+				logger.Printf("Tracking cookie enabled - not currently used")
+				//wsCfg.EnableTrackingCookie = true
+			}
+			if conf.WebSocket.EnableRequestCapture {
+				logger.Printf("Request capture enabled - not currently used")
+				//wsCfg.EnableRequestCapture = true
 			}
 			// Set optional websocket config.
 			wss.SetConfig(wsCfg)

--- a/nexusd/main.go
+++ b/nexusd/main.go
@@ -60,14 +60,20 @@ func main() {
 	if conf.WebSocket.Address != "" {
 		// Create a new websocket server with the router.
 		wss := router.NewWebsocketServer(r)
-		if conf.WebSocket.EnableCompression {
-			logger.Printf("Compression enabled")
+		if conf.WebSocket.EnableCompression || conf.WebSocket.EnableTrackingCookie {
+			var wsCfg transport.WebsocketConfig
+			if conf.WebSocket.EnableCompression {
+				logger.Printf("Compression enabled")
+				wsCfg.EnableCompression = true
+				wsCfg.EnableContextTakeover = conf.WebSocket.EnableContextTakeover
+				wsCfg.CompressionLevel = conf.WebSocket.CompressionLevel
+			}
+			if conf.WebSocket.EnableTrackingCookie {
+				logger.Printf("Cookie tracking enabled")
+				wsCfg.EnableTrackingCookie = true
+			}
 			// Set optional websocket config.
-			wss.SetConfig(transport.WebsocketConfig{
-				EnableCompression:     true,
-				EnableContextTakeover: conf.WebSocket.EnableContextTakeover,
-				CompressionLevel:      conf.WebSocket.CompressionLevel,
-			})
+			wss.SetConfig(wsCfg)
 		}
 
 		var closer io.Closer

--- a/router/auth/authenticator.go
+++ b/router/auth/authenticator.go
@@ -23,20 +23,20 @@ type Authenticator interface {
 	// Authenticate takes HELLO details and returns a WELCOME message if
 	// successful, otherwise it returns an error.
 	//
-	// If the client was a websocket peer, then the websocket upgrade request
-	// is available from the client.
+	// If the client is a websocket peer, and request capture is enabled, then
+	// the HTTP request is stored in details.  If cookie tracking is enabled,
+	// then the cookie from the request, and the next cookie to expect, are
+	// also stored in details.
 	//
-	//    httpReq := transport.WSRequest(client)
+	// These websocket data items are available as:
 	//
-	// If cookie tracking is also enabled, then a subsequent request from the
-	// client will include an expected cookie.  That expected cookie isa
-	// available from the client and can be retireved with a helper function:
+	//     details.auth.request|*http.Request
+	//     details.transport.auth.cookie|*http.Cookie
+	//     details.transport.auth.nextcookie|*http.Cookie
 	//
-	//    expectedCookie := transport.WSNextCookie(client)
-	//
-	// The tracking cookie can be used to tell if a previous clien to the
-	// router, and lookup information about that client, such as whether it was
-	// previously authenticated.
+	// The tracking cookie can be used to tell if a client was previously
+	// connected to the router, and lookup information about that client, such
+	// as whether it was successfully authenticated.
 	Authenticate(sid wamp.ID, details wamp.Dict, client wamp.Peer) (*wamp.Welcome, error)
 
 	// AuthMethod returns a string describing the authentication methiod.
@@ -60,7 +60,7 @@ type KeyStore interface {
 }
 
 // BypassKeyStore is a KeyStore with additional functionality for looking at
-// HELLO/Session details, including transport information, to recognize clients
+// HELLO.Details, including transport.auth information, to recognize clients
 // that have been previously authenticated.
 //
 // When used with the provided CR and ticket authenticators, if AlreadyAuth

--- a/router/auth/authenticator.go
+++ b/router/auth/authenticator.go
@@ -22,6 +22,21 @@ const defaultCRAuthTimeout = time.Minute
 type Authenticator interface {
 	// Authenticate takes HELLO details and returns a WELCOME message if
 	// successful, otherwise it returns an error.
+	//
+	// If the client was a websocket peer, then the websocket upgrade request
+	// is available from the client.
+	//
+	//    httpReq := transport.WSRequest(client)
+	//
+	// If cookie tracking is also enabled, then a subsequent request from the
+	// client will include an expected cookie.  That expected cookie isa
+	// available from the client and can be retireved with a helper function:
+	//
+	//    expectedCookie := transport.WSNextCookie(client)
+	//
+	// The tracking cookie can be used to tell if a previous clien to the
+	// router, and lookup information about that client, such as whether it was
+	// previously authenticated.
 	Authenticate(sid wamp.ID, details wamp.Dict, client wamp.Peer) (*wamp.Welcome, error)
 
 	// AuthMethod returns a string describing the authentication methiod.
@@ -42,4 +57,31 @@ type KeyStore interface {
 
 	// Returns name of this KeyStore instnace.
 	Provider() string
+}
+
+// BypassKeyStore is a KeyStore with additional functionality for looking at
+// HELLO/Session details, including transport information, to recognize clients
+// that have been previously authenticated.
+//
+// When used with the provided CR and ticket authenticators, if AlreadyAuth
+// returns true, then the normal authentication method is bypassed.
+type BypassKeyStore interface {
+	KeyStore
+
+	// AlreadyAuth takes information about a HELLO request including transport
+	// details.  If the client is a websocket client, then information from the
+	// HTTP upgrade request, the tracking cookie ID from the request, and next
+	// tracking cookie ID (if enabled) are available in
+	// details.transport.auth|Dict.
+	//
+	// If the client is recognized and already authenticated, then AlreadyAuth
+	// returns true.  Otherwise, false is returned if not authenticated.
+	AlreadyAuth(authid string, details wamp.Dict) bool
+
+	// OnWelcome is called when a client is successfully authenticated.  This
+	// allows the KeyStore to update any information about the authenticated
+	// client, to modify the welcome message, and to store the next tracking
+	// cookie ID to expect from the client.  The request information and the
+	// next cookie ID are available from in details.transport.auth|Dict.
+	OnWelcome(authid string, welcome *wamp.Welcome, details wamp.Dict) error
 }

--- a/router/auth/authenticator.go
+++ b/router/auth/authenticator.go
@@ -35,11 +35,11 @@ type Authenticator interface {
 	//     details.transport.auth.nextcookie|*http.Cookie
 	//
 	// The tracking cookie can be used to tell if a client was previously
-	// connected to the router, and lookup information about that client, such
+	// connected to the router, and look up information about that client, such
 	// as whether it was successfully authenticated.
 	Authenticate(sid wamp.ID, details wamp.Dict, client wamp.Peer) (*wamp.Welcome, error)
 
-	// AuthMethod returns a string describing the authentication methiod.
+	// AuthMethod returns a string describing the authentication method.
 	AuthMethod() string
 }
 
@@ -55,7 +55,7 @@ type KeyStore interface {
 	// Returns the authrole for the user.
 	AuthRole(authid string) (string, error)
 
-	// Returns name of this KeyStore instnace.
+	// Returns name of this KeyStore instance.
 	Provider() string
 }
 

--- a/router/auth/crauth_test.go
+++ b/router/auth/crauth_test.go
@@ -14,6 +14,9 @@ type testKeyStore struct {
 	provider string
 	secret   string
 	ticket   string
+	cookieid string
+
+	authByCookie bool
 }
 
 const (
@@ -32,14 +35,8 @@ func (ks *testKeyStore) AuthKey(authid, authmethod string) ([]byte, error) {
 	case "ticket":
 		return []byte(ks.ticket), nil
 	}
-	return nil, nil
+	return nil, errors.New("unsupported authmethod")
 }
-
-func (ks *testKeyStore) PasswordInfo(authid string) (string, int, int) {
-	return "", 0, 0
-}
-
-func (ks *testKeyStore) Provider() string { return ks.provider }
 
 func (ks *testKeyStore) AuthRole(authid string) (string, error) {
 	if authid != "jdoe" {
@@ -48,7 +45,48 @@ func (ks *testKeyStore) AuthRole(authid string) (string, error) {
 	return "user", nil
 }
 
-var tks = &testKeyStore{"static", goodSecret, goodTicket}
+func (ks *testKeyStore) PasswordInfo(authid string) (string, int, int) {
+	return "", 0, 0
+}
+
+func (ks *testKeyStore) Provider() string { return ks.provider }
+
+func (ks *testKeyStore) AlreadyAuth(authid string, details wamp.Dict) bool {
+	v, err := wamp.DictValue(details, []string{"transport", "auth", "cookieid"})
+	if err != nil {
+		// No tracking cookie, so not auth.
+		return false
+	}
+	cookieid, ok := wamp.AsString(v)
+	if ok {
+		// Tracking cookie matches cookie of previously good client.
+		if cookieid == ks.cookieid {
+			ks.authByCookie = true
+			return true
+		}
+	}
+	return false
+}
+
+func (ks *testKeyStore) OnWelcome(authid string, welcome *wamp.Welcome, details wamp.Dict) error {
+	v, err := wamp.DictValue(details, []string{"transport", "auth", "nextcookieid"})
+	if err != nil {
+		return nil
+	}
+	nextcookieid, ok := wamp.AsString(v)
+	if ok {
+		// Update tracking cookie that will identify this authenticated client.
+		ks.cookieid = nextcookieid
+	}
+	welcome.Details["authbycookie"] = ks.authByCookie
+	return nil
+}
+
+var tks = &testKeyStore{
+	provider: "static",
+	secret:   goodSecret,
+	ticket:   goodTicket,
+}
 
 func cliRsp(p wamp.Peer) {
 	for msg := range p.Recv() {
@@ -103,6 +141,10 @@ func TestTicketAuth(t *testing.T) {
 
 	// Test with known authid.
 	details["authid"] = "jdoe"
+	// Provide tracking cookie to ientify this client in the future.
+	authDict := wamp.Dict{"nextcookieid": "a1b2c3"}
+	details["transport"] = wamp.Dict{"auth": authDict}
+
 	welcome, err = ticketAuth.Authenticate(sid, details, rp)
 	if err != nil {
 		t.Fatal("challenge failed: ", err.Error())
@@ -119,7 +161,9 @@ func TestTicketAuth(t *testing.T) {
 	if wamp.OptionString(welcome.Details, "authrole") != "user" {
 		t.Fatal("incorrect authrole in welcome details")
 	}
-
+	if wamp.OptionFlag(welcome.Details, "authbycookie") {
+		t.Fatal("authbycookie set incorrectly to true")
+	}
 	tks.ticket = "bad"
 
 	// Test with bad ticket.
@@ -127,6 +171,21 @@ func TestTicketAuth(t *testing.T) {
 	welcome, err = ticketAuth.Authenticate(sid, details, rp)
 	if err == nil {
 		t.Fatal("expected error with bad ticket")
+	}
+
+	// Supply the previous tracking cookie in transport.auth.  This will
+	// identify the previously authenticated client.
+	authDict["cookieid"] = "a1b2c3"
+	authDict["nextcookieid"] = "xyz123"
+	welcome, err = ticketAuth.Authenticate(sid, details, rp)
+	// Event though ticket is bad, cookie from previous good session should
+	// authenticate client.
+	if err != nil {
+		t.Fatal("challenge failed: ", err.Error())
+	}
+	// Client should be authenticated by cookie.
+	if !wamp.OptionFlag(welcome.Details, "authbycookie") {
+		t.Fatal("authbycookie set incorrectly to false")
 	}
 }
 
@@ -155,6 +214,9 @@ func TestCRAuth(t *testing.T) {
 
 	// Test with known authid.
 	details["authid"] = "jdoe"
+	authDict := wamp.Dict{"nextcookieid": "a1b2c3"}
+	details["transport"] = wamp.Dict{"auth": authDict}
+
 	welcome, err = crAuth.Authenticate(sid, details, rp)
 	if err != nil {
 		t.Fatal("challenge failed: ", err.Error())
@@ -179,5 +241,12 @@ func TestCRAuth(t *testing.T) {
 	welcome, err = crAuth.Authenticate(sid, details, rp)
 	if err == nil {
 		t.Fatal("expected error with bad key")
+	}
+
+	authDict["cookieid"] = "a1b2c3"
+	authDict["nextcookieid"] = "xyz123"
+	welcome, err = crAuth.Authenticate(sid, details, rp)
+	if err != nil {
+		t.Fatal("challenge failed: ", err.Error())
 	}
 }

--- a/router/auth/ticket.go
+++ b/router/auth/ticket.go
@@ -42,7 +42,7 @@ func (t *TicketAuthenticator) Authenticate(sid wamp.ID, details wamp.Dict, clien
 
 	authrole, err := t.keyStore.AuthRole(authID)
 	if err != nil {
-		return nil, err
+		authrole = ""
 	}
 
 	ks, ok := t.keyStore.(BypassKeyStore)
@@ -66,7 +66,9 @@ func (t *TicketAuthenticator) Authenticate(sid wamp.ID, details wamp.Dict, clien
 
 	ticket, err := t.keyStore.AuthKey(authID, t.AuthMethod())
 	if err != nil {
-		return nil, err
+		// Do not return error here as this leaks authid.  Instead, set the
+		// ticket to nil which will prevent it from authenticating.
+		ticket = nil
 	}
 
 	// Challenge Extra map is empty since the ticket challenge only asks for a
@@ -93,7 +95,7 @@ func (t *TicketAuthenticator) Authenticate(sid wamp.ID, details wamp.Dict, clien
 	// The client will send an AUTHENTICATE message containing a ticket.  The
 	// server will then check if the ticket provided is permissible (for the
 	// authid given).
-	if authRsp.Signature != string(ticket) {
+	if ticket == nil || authRsp.Signature != string(ticket) {
 		return nil, errors.New("invalid ticket")
 	}
 

--- a/router/rawsocketserver.go
+++ b/router/rawsocketserver.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/gammazero/nexus/stdlog"
 	"github.com/gammazero/nexus/transport"
-	"github.com/gammazero/nexus/wamp"
 )
 
 // RawSocketServer handles socket connections.
@@ -109,7 +108,7 @@ func (s *RawSocketServer) handleRawSocket(conn net.Conn) {
 		return
 	}
 
-	if err := s.router.AttachClient(peer, wamp.Dict{"type": "rawsocket"}); err != nil {
+	if err := s.router.Attach(peer); err != nil {
 		s.log.Println("Error attaching to router:", err)
 	}
 }

--- a/router/rawsocketserver.go
+++ b/router/rawsocketserver.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gammazero/nexus/stdlog"
 	"github.com/gammazero/nexus/transport"
+	"github.com/gammazero/nexus/wamp"
 )
 
 // RawSocketServer handles socket connections.
@@ -108,7 +109,7 @@ func (s *RawSocketServer) handleRawSocket(conn net.Conn) {
 		return
 	}
 
-	if err := s.router.Attach(peer); err != nil {
+	if err := s.router.AttachClient(peer, wamp.Dict{"type": "rawsocket"}); err != nil {
 		s.log.Println("Error attaching to router:", err)
 	}
 }

--- a/router/realm.go
+++ b/router/realm.go
@@ -492,12 +492,6 @@ func (r *realm) authClient(sid wamp.ID, client wamp.Peer, details wamp.Dict) (*w
 		return &wamp.Welcome{Details: details}, nil
 	}
 
-	_, err := wamp.DictValue(details, []string{"transport", "auth", "wsrequest"})
-	if err == nil {
-		//req = v.(*http.Request)
-		fmt.Println("---> Got HTTP request from transport")
-	}
-
 	// The default authentication method is "WAMP-Anonymous" if client does not
 	// specify otherwise.
 	if _, ok := details["authmethods"]; !ok {

--- a/router/realm.go
+++ b/router/realm.go
@@ -252,12 +252,14 @@ func (r *realm) onJoin(sess *wamp.Session) {
 	// Session Meta Events MUST be dispatched by the Router to the same realm
 	// as the WAMP session which triggered the event.
 	//
-	// WAMP spec only specifies publishing "authid", "authrole", "authmethod",
-	// "authprovider", "transport".  This implementation publishes all details.
+	// WAMP spec only specifies publishing "session", "authid", "authrole",
+	// "authmethod", "authprovider", "transport".  This implementation
+	// publishes all details except transport.auth.
+	output := cleanSessionDetails(sess.Details)
 	r.metaPeer.Send(&wamp.Publish{
 		Request:   wamp.GlobalID(),
 		Topic:     wamp.MetaEventSessionOnJoin,
-		Arguments: wamp.List{sess.Details},
+		Arguments: wamp.List{output},
 	})
 }
 
@@ -490,6 +492,12 @@ func (r *realm) authClient(sid wamp.ID, client wamp.Peer, details wamp.Dict) (*w
 		return &wamp.Welcome{Details: details}, nil
 	}
 
+	_, err := wamp.DictValue(details, []string{"transport", "auth", "wsrequest"})
+	if err == nil {
+		//req = v.(*http.Request)
+		fmt.Println("---> Got HTTP request from transport")
+	}
+
 	// The default authentication method is "WAMP-Anonymous" if client does not
 	// specify otherwise.
 	if _, ok := details["authmethods"]; !ok {
@@ -714,11 +722,45 @@ func (r *realm) sessionGet(msg *wamp.Invocation) wamp.Message {
 		return makeErr()
 	}
 
-	// WAMP spec only specifies returning "authid", "authrole", "authmethod",
-	// "authprovider", and "transport".  All details are returned in this
-	// implementation.
+	output := cleanSessionDetails(sess.Details)
+
+	// WAMP spec only specifies returning "session", "authid", "authrole",
+	// "authmethod", "authprovider", and "transport".  All details are returned
+	// in this implementation, except transport.auth.
 	return &wamp.Yield{
 		Request:   msg.Request,
-		Arguments: wamp.List{sess.Details},
+		Arguments: wamp.List{output},
 	}
+}
+
+// cleanSessionDetails removed transport.auth from the details.  This is used
+// to prevent exposing auth information to session meta.
+func cleanSessionDetails(details wamp.Dict) wamp.Dict {
+	_, err := wamp.DictValue(details, []string{"transport", "auth"})
+	if err != nil {
+		return details
+	}
+
+	var altTrans wamp.Dict
+	for n, v := range wamp.DictChild(details, "transport") {
+		if n == "auth" {
+			continue
+		}
+		if altTrans == nil {
+			altTrans = wamp.Dict{}
+		}
+		altTrans[n] = v
+	}
+
+	output := wamp.Dict{}
+	for n, v := range details {
+		if n == "transport" {
+			if len(altTrans) > 0 {
+				output[n] = altTrans
+			}
+			continue
+		}
+		output[n] = v
+	}
+	return output
 }

--- a/router/realm.go
+++ b/router/realm.go
@@ -733,8 +733,9 @@ func (r *realm) sessionGet(msg *wamp.Invocation) wamp.Message {
 	}
 }
 
-// cleanSessionDetails removed transport.auth from the details.  This is used
-// to prevent exposing auth information to session meta.
+// cleanSessionDetails removes transport.auth from the details.  This is done
+// because the data in transport.auth may not be serializable and to prevent
+// exposing auth information to session meta.
 func cleanSessionDetails(details wamp.Dict) wamp.Dict {
 	_, err := wamp.DictValue(details, []string{"transport", "auth"})
 	if err != nil {

--- a/router/router.go
+++ b/router/router.go
@@ -113,32 +113,22 @@ func NewRouter(config *RouterConfig, logger stdlog.StdLog) (Router, error) {
 // Logger returns the StdLog that the router uses for logging.
 func (r *router) Logger() stdlog.StdLog { return r.log }
 
+// Attach connects a client to the router and to the requested realm.  If
+// successful, Attach returns after sending a WELCOME message to the client.
 func (r *router) Attach(client wamp.Peer) error {
 	return r.AttachClient(client, nil)
 }
 
-// Attach connects a client to the router and to the requested realm.  If
+// AttachClient connects a client to the router and to the requested realm.  If
 // successful, Attach returns after sending a WELCOME message to the client.
 //
 // Additional information is provided in transportDetails.  This information
 // becomes part of HELLO.Details and session.Details, as details["transport"].
-// This exposes it to auth/authz.  The information includes items useful for
-// authentication, in details.transport.auth.  If the client is a websocket
-// client, then transportDetails will contain the following:
+// This exposes it to authenticator and authorizer logic.  The information
+// includes items useful for authentication, in details.transport.auth.
 //
-//     auth.request
-//     auth.cookieid
-//     auth.nextcookieid
-//
-// auth.request contains information for the HTTP upgrade request.
-// auth.cookieid is the value of the tracking cookie that was present in the
-// request, and auth.nextcookieid is the value of the tracking cookie that was
-// sent to the client in response to the upgrade request.  This cookie can be
-// used to track if the same client was previously seen, and lookup information
-// about that client, such a whether it was previously authenticated.  This
-// information will not be present if the client was not a websocket, and
-// cookieids will not be present if cookie tracking is not enabled for the
-// router.
+// See websocketpeer.WebSocketConfig for information provided by websocket
+// connections.
 func (r *router) AttachClient(client wamp.Peer, transportDetails wamp.Dict) error {
 	sendAbort := func(reason wamp.URI, abortErr error) {
 		abortMsg := wamp.Abort{Reason: reason}

--- a/router/router.go
+++ b/router/router.go
@@ -252,7 +252,9 @@ func (r *router) AttachClient(client wamp.Peer, transportDetails wamp.Dict) erro
 	}
 
 	// Include any transport details with HELLO.Details.
-	hello.Details["transport"] = transportDetails
+	if len(transportDetails) != 0 {
+		hello.Details["transport"] = transportDetails
+	}
 
 	// Handle any necessary client auth.  This results in either a WELCOME
 	// message or an error.

--- a/transport/websocketpeer.go
+++ b/transport/websocketpeer.go
@@ -54,6 +54,9 @@ type WebsocketConfig struct {
 	// request in the HELLO and session details.  It is stored in
 	// Details.transport.auth.request|*http.Request and is available to
 	// auth/authz logic.
+	//
+	// EnableTrackingCookie and EnableRequestCapture is configured for the
+	// server by passing WebsocketConfig to WebsocketServer.SetConfig().
 	EnableRequestCapture bool `json:"enable_request_capture"`
 
 	// For websocket client configuration only

--- a/transport/websocketpeer.go
+++ b/transport/websocketpeer.go
@@ -21,6 +21,18 @@ type WebsocketConfig struct {
 	EnableCompression     bool `json:"enable_compression"`
 	EnableContextTakeover bool `json:"enable_context_takeover"`
 	CompressionLevel      int  `json:"compression_level"`
+
+	// Tells server to send random cookie to websocket client.  This cookie can
+	// be sent with subsequent websocket requests to identify the returning
+	// client.  Only used for WebsocketServer configuration.
+	EnableTrackingCookie bool `json:"enable_tracking_cookie"`
+
+	// If provided when configuring websocket client, cookies from server are
+	// put in here.  This allows cookies to be stored and then sent back to the
+	// server in subsequent websocket connections.  Cookies may be used to
+	// identify returning clients, and can be used to authenticate clients.
+	// Olny used for websocket client configuration.
+	Jar http.CookieJar
 }
 
 // websocketPeer implements the Peer interface, connecting the Send and Recv
@@ -86,6 +98,8 @@ func ConnectWebsocketPeer(url string, serialization serialize.Serialization, tls
 		dialer.EnableCompression = wsCfg.EnableCompression
 		//dialer.EnableContextTakeover = wsCfg.EnableContextTakeover
 		//dialer.CompressionLevel = wsCfg.CompressionLevel
+
+		dialer.Jar = wsCfg.Jar
 	}
 
 	conn, _, err := dialer.Dial(url, nil)

--- a/transport/websocketpeer.go
+++ b/transport/websocketpeer.go
@@ -28,9 +28,9 @@ type WebsocketConfig struct {
 	// the websocket client.  A returning client may identify itself by sending
 	// a previously issued tracking cookie in a websocket request.  If a
 	// request header received by the server contains the tracking cookie, then
-	// it is included in the HELLO and session details.  The tracking cookie
-	// sent to the client (the cookie to expect for subsequent connections) is
-	// also stored in HELLO and session details.
+	// the cookie is included in the HELLO and session details.  The new
+	// tracking cookie that gets sent to the client (the cookie to expect for
+	// subsequent connections) is also stored in HELLO and session details.
 	//
 	// The cookie from the request, and the next cookie to expect, are
 	// stored in the HELLO and session details, respectively, as:


### PR DESCRIPTION
In the `WebsocketConfig` used to configure the router, there are two new boolean values: `EnableTrackingCookie` and `EnableRequestCapture`

`EnableTrackingCookie` tells the server to send a random-value cookie to the websocket client.  A returning client may identify itself by sending a previously issued tracking cookie in a websocket request.  If a request header received by the server contains the tracking cookie, then the cookie is included in the HELLO and session details.  The new tracking cookie that gets sent to the client (the cookie to expect for subsequent connections) is also stored in HELLO and session details.                                

The cookie from the request, and the next cookie to expect, are stored in the HELLO and session details, respectively, as:
 ```                                        
 Details.transport.auth.cookie|*http.Cookie                           
 Details.transport.auth.nextcookie|*http.Cookie
```                       
                                                                          
This information is available to auth/authz logic, and can be retrieved from details as follows:                                                 
```
req *http.Request
v, err := wamp.DictValue(details, []string{"transport", "auth", "request"})                              
if err == nil {
    req = v.(*http.Request)
}
```
The "cookie" and "nextcookie" values are retrieved similarly. 

`EnableRequestCapture` tells the server to include the upgrade HTTP request in the HELLO and session details.  It is stored in `Details.transport.auth.request|*http.Request` and is available to auth/authz logic.