### PR TITLE
Serverconfig

### DIFF
--- a/aat/main_test.go
+++ b/aat/main_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net/http"
 	"net/http/cookiejar"
 	"os"
 	"path"

--- a/aat/main_test.go
+++ b/aat/main_test.go
@@ -346,17 +346,3 @@ func TestHandshake(t *testing.T) {
 		t.Fatal("Expected error if client already closed")
 	}
 }
-
-func testCheckOrigin(r *http.Request) bool {
-	u, ok := r.Header["Upgrade"]
-	if ok {
-		fmt.Println("---> Upgrade header:", u)
-	}
-	origin, ok := r.Header["Origin"]
-	if ok {
-		fmt.Println("---> Origin header:", origin)
-	} else {
-		fmt.Println("---> No origin header")
-	}
-	return true
-}

--- a/examples/server/server.go
+++ b/examples/server/server.go
@@ -12,7 +12,6 @@ import (
 	"path"
 
 	"github.com/gammazero/nexus/router"
-	"github.com/gammazero/nexus/transport"
 	"github.com/gammazero/nexus/wamp"
 )
 

--- a/examples/server/server.go
+++ b/examples/server/server.go
@@ -44,13 +44,14 @@ func main() {
 	}
 	defer nxr.Close()
 
-	// Create websocket and rawsocket servers.  Websocket comopression enabled,
-	// will be used if clients request it.
+	// Create websocket server.
 	wss := router.NewWebsocketServer(nxr)
-	wss.SetConfig(transport.WebsocketConfig{
-		EnableCompression:    true,
-		EnableTrackingCookie: true,
-	})
+	// Enable websocket compression, which will be used if clients request it.
+	wss.Upgrader.EnableCompression = true
+	// Configure server to send and look for client tracking cookie.
+	wss.EnableTrackingCookie = true
+
+	// Create rawsocket server.
 	rss := router.NewRawSocketServer(nxr, 0, 0)
 
 	// ---- Start servers ----

--- a/examples/simple/pub/publisher.go
+++ b/examples/simple/pub/publisher.go
@@ -13,12 +13,12 @@ const exampleTopic = "example.hello"
 func main() {
 	logger := log.New(os.Stdout, "", 0)
 	cfg := client.ClientConfig{
-		Realm:  "nexus.examples",
+		Realm:  "nexus.realm1",
 		Logger: logger,
 	}
 
 	// Connect publisher session.
-	publisher, err := client.ConnectNet("ws://localhost:8000/", cfg)
+	publisher, err := client.ConnectNet("ws://localhost:8080/", cfg)
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/examples/simple/server.go
+++ b/examples/simple/server.go
@@ -13,14 +13,14 @@ import (
 	"github.com/gammazero/nexus/wamp"
 )
 
-const address = "127.0.0.1:8000"
+const address = "127.0.0.1:8080"
 
 func main() {
 	// Create router instance.
 	routerConfig := &router.RouterConfig{
 		RealmConfigs: []*router.RealmConfig{
 			&router.RealmConfig{
-				URI:           wamp.URI("nexus.examples"),
+				URI:           wamp.URI("nexus.realm1"),
 				AnonymousAuth: true,
 			},
 		},

--- a/examples/simple/sub/subscriber.go
+++ b/examples/simple/sub/subscriber.go
@@ -14,12 +14,12 @@ const exampleTopic = "example.hello"
 func main() {
 	logger := log.New(os.Stdout, "", 0)
 	cfg := client.ClientConfig{
-		Realm:  "nexus.examples",
+		Realm:  "nexus.realm1",
 		Logger: logger,
 	}
 
 	// Connect subscriber session.
-	subscriber, err := client.ConnectNet("ws://localhost:8000/", cfg)
+	subscriber, err := client.ConnectNet("ws://localhost:8080/", cfg)
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/nexusd/config.go
+++ b/nexusd/config.go
@@ -18,9 +18,8 @@ type Config struct {
 		CertFile string `json:"cert_file"`
 		KeyFile  string `json:"key_file"`
 		// Enable per message write compression.
-		EnableCompression     bool `json:"enable_compression"`
-		EnableContextTakeover bool `json:"enable_context_takeover"`
-		CompressionLevel      int  `json:"compression_level"`
+		EnableCompression    bool `json:"enable_compression"`
+		AllowContextTakeover bool `json:"allow_context_takeover"`
 		// Enable sending cookie to identify client in later connections.
 		EnableTrackingCookie bool `json:"enable_tracking_cookie"`
 		// Enable reading HTTP header from client requests.

--- a/nexusd/config.go
+++ b/nexusd/config.go
@@ -25,6 +25,9 @@ type Config struct {
 		EnableTrackingCookie bool `json:"enable_tracking_cookie"`
 		// Enable reading HTTP header from client requests.
 		EnableRequestCapture bool `json:"enable_request_capture"`
+		// Allow origins that match these glob patterns when an origin header
+		// is present in the websocket upgrade request.
+		AllowOrigins []string `json:"allow_origins"`
 	}
 
 	// RawSocket configuration parameters.

--- a/nexusd/etc/nexus.json
+++ b/nexusd/etc/nexus.json
@@ -3,7 +3,8 @@
         "address": ":8080",
         "cert_file": "",
         "key_file": "",
-        "enable_compression": false
+        "enable_compression": false,
+        "allow_origins": []
     },
     "rawsocket": {
         "tcp_address": "",

--- a/nexusd/etc/nexus.json
+++ b/nexusd/etc/nexus.json
@@ -17,10 +17,10 @@
     "router": {
         "realms": [
             {
-                "uri": "nexus.reaml1",
+                "uri": "nexus.realm1",
                 "strict_uri": false,
                 "allow_disclose": true,
-                "allow_anonymous": true
+                "anonymous_auth": true
             }
         ],
         "debug": false

--- a/nexusd/main.go
+++ b/nexusd/main.go
@@ -72,7 +72,13 @@ func main() {
 			wss.EnableRequestCapture = true
 			logger.Printf("Request capture enabled - not currently used")
 		}
-
+		if len(conf.WebSocket.AllowOrigins) != 0 {
+			err = wss.AllowOrigins(conf.WebSocket.AllowOrigins)
+			if err != nil {
+				logger.Print(err)
+				os.Exit(1)
+			}
+		}
 		var closer io.Closer
 		var sockDesc string
 		if conf.WebSocket.CertFile != "" && conf.WebSocket.KeyFile != "" {

--- a/nexusd/main.go
+++ b/nexusd/main.go
@@ -11,8 +11,10 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
+	"github.com/gammazero/nexus/nexusd/wsutil"
 	"github.com/gammazero/nexus/router"
 )
 
@@ -73,11 +75,14 @@ func main() {
 			logger.Printf("Request capture enabled - not currently used")
 		}
 		if len(conf.WebSocket.AllowOrigins) != 0 {
-			err = wss.AllowOrigins(conf.WebSocket.AllowOrigins)
-			if err != nil {
-				logger.Print(err)
+			check, e := wsutil.AllowOrigins(conf.WebSocket.AllowOrigins)
+			if e != nil {
+				logger.Print(e)
 				os.Exit(1)
 			}
+			logger.Println("Allowing origins matching:",
+				strings.Join(conf.WebSocket.AllowOrigins, "|"))
+			wss.Upgrader.CheckOrigin = check
 		}
 		var closer io.Closer
 		var sockDesc string

--- a/nexusd/main.go
+++ b/nexusd/main.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/gammazero/nexus/router"
-	"github.com/gammazero/nexus/transport"
 )
 
 func usage() {
@@ -60,24 +59,18 @@ func main() {
 	if conf.WebSocket.Address != "" {
 		// Create a new websocket server with the router.
 		wss := router.NewWebsocketServer(r)
-		if conf.WebSocket.EnableCompression || conf.WebSocket.EnableTrackingCookie {
-			var wsCfg transport.WebsocketConfig
-			if conf.WebSocket.EnableCompression {
-				logger.Printf("Compression enabled")
-				wsCfg.EnableCompression = true
-				wsCfg.EnableContextTakeover = conf.WebSocket.EnableContextTakeover
-				wsCfg.CompressionLevel = conf.WebSocket.CompressionLevel
-			}
-			if conf.WebSocket.EnableTrackingCookie {
-				logger.Printf("Tracking cookie enabled - not currently used")
-				//wsCfg.EnableTrackingCookie = true
-			}
-			if conf.WebSocket.EnableRequestCapture {
-				logger.Printf("Request capture enabled - not currently used")
-				//wsCfg.EnableRequestCapture = true
-			}
-			// Set optional websocket config.
-			wss.SetConfig(wsCfg)
+		if conf.WebSocket.EnableCompression {
+			wss.Upgrader.EnableCompression = true
+			//wss.Upgrader.AllowServerContextTakeover = conf.WebSocket.EnableContextTakeover
+			logger.Printf("Compression enabled")
+		}
+		if conf.WebSocket.EnableTrackingCookie {
+			wss.EnableTrackingCookie = true
+			logger.Printf("Tracking cookie enabled - not currently used")
+		}
+		if conf.WebSocket.EnableRequestCapture {
+			wss.EnableRequestCapture = true
+			logger.Printf("Request capture enabled - not currently used")
 		}
 
 		var closer io.Closer

--- a/nexusd/main.go
+++ b/nexusd/main.go
@@ -63,7 +63,7 @@ func main() {
 		wss := router.NewWebsocketServer(r)
 		if conf.WebSocket.EnableCompression {
 			wss.Upgrader.EnableCompression = true
-			//wss.Upgrader.AllowServerContextTakeover = conf.WebSocket.EnableContextTakeover
+			//wss.Upgrader.AllowServerContextTakeover = conf.WebSocket.AllowContextTakeover
 			logger.Printf("Compression enabled")
 		}
 		if conf.WebSocket.EnableTrackingCookie {

--- a/nexusd/wsutil/alloworigins.go
+++ b/nexusd/wsutil/alloworigins.go
@@ -1,0 +1,71 @@
+/*
+Package wsutil provides websocket server utilities.
+
+*/
+package wsutil
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+)
+
+// AllowOriginsGlob returns a function, sutiable for setting
+// WebsocketServer.Upgrader.CheckOrigin, that returns true if: the origin is
+// not set, is equal to the request host, or matches one of the allowed
+// patterns.  A pattern is in the form of a shell glob as described here:
+// https://golang.org/pkg/path/filepath/#Match
+func AllowOrigins(origins []string) (func(r *http.Request) bool, error) {
+	if len(origins) == 0 {
+		return nil, nil
+	}
+	var exacts, globs []string
+	for _, o := range origins {
+		// Do exact matching whenever possible, since it is more efficient and
+		// does not produce garbage.
+		if strings.ContainsAny(o, "*?[]^") {
+			if _, err := filepath.Match(o, o); err != nil {
+				return nil, fmt.Errorf("error allowing origin, %s: %s", err, o)
+			}
+			globs = append(globs, strings.ToLower(o))
+		} else {
+			exacts = append(exacts, o)
+		}
+	}
+	return func(r *http.Request) bool {
+		return checkOrigin(exacts, globs, r)
+	}, nil
+}
+
+// checkOrigin returns true if the origin is not set, is equal to the
+// request host, or matches one of the allowed patterns.
+func checkOrigin(exacts, globs []string, r *http.Request) bool {
+	origin := r.Header["Origin"]
+	if len(origin) == 0 {
+		return true
+	}
+	u, err := url.Parse(origin[0])
+	if err != nil {
+		return false
+	}
+	if strings.EqualFold(u.Host, r.Host) {
+		return true
+	}
+
+	for i := range exacts {
+		if strings.EqualFold(u.Host, exacts[i]) {
+			return true
+		}
+	}
+	if len(globs) != 0 {
+		host := strings.ToLower(u.Host)
+		for i := range globs {
+			if ok, _ := filepath.Match(globs[i], host); ok {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/nexusd/wsutil/alloworigins_test.go
+++ b/nexusd/wsutil/alloworigins_test.go
@@ -1,0 +1,37 @@
+package wsutil
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestAllowOrigins(t *testing.T) {
+	check, err := AllowOrigins([]string{"*foo.bAr.CoM", "*.bar.net",
+		"Hello.世界", "Hello.世界.*.com", "Sevastopol.Seegson.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := http.NewRequest("GET", "http://nowhere.net", nil)
+	if err != nil {
+		t.Fatal("Failed to create request:", err)
+	}
+	for _, allowed := range []string{"http://foo.bar.com",
+		"http://snafoo.bar.com", "http://a.b.c.baz.bar.net",
+		"http://hello.世界", "http://hello.世界.X.com",
+		"https://sevastopol.seegson.com"} {
+		r.Header.Set("Origin", allowed)
+		if !check(r) {
+			t.Error("Should have allowed:", allowed)
+		}
+	}
+	for _, denied := range []string{"http://cat.bar.com",
+		"http://a.bar.net.com", "http://hello.世界.X.nex"} {
+		r.Header.Set("Origin", denied)
+		if check(r) {
+			t.Error("Should have denied:", denied)
+		}
+	}
+	if _, err = AllowOrigins([]string{"foo.bar.co["}); err == nil {
+		t.Fatal("Expected error")
+	}
+}

--- a/router/router.go
+++ b/router/router.go
@@ -279,7 +279,7 @@ func (r *router) AttachClient(client wamp.Peer, transportDetails wamp.Dict) erro
 	}
 
 	if err := realm.handleSession(sess); err != nil {
-		// N.B. assume, for now, that any error is a shutdown error
+		// Any error returned here is a shutdown error.
 		sendAbort(wamp.ErrSystemShutdown, nil)
 		return err
 	}

--- a/router/router.go
+++ b/router/router.go
@@ -327,14 +327,15 @@ func (r *router) AddRealm(config *RealmConfig) error {
 
 // RemoveRealm will close and then remove a realm from this router, if the realm exists.
 func (r *router) RemoveRealm(name wamp.URI) {
-	// Because we want to force atomicity as briefly as possible, the atomic func will be used purely to attempt to
-	// locate the realm
+	// Because we want to force atomicity as briefly as possible, the atomic
+	// func will be used purely to attempt to locate the realm
 	var realm *realm
 	var ok bool
 	sync := make(chan struct{})
 	r.actionChan <- func() {
 		if realm, ok = r.realms[name]; ok {
-			// if found, go ahead and remove the realm from the router to prevent new clients from joining it.
+			// if found, go ahead and remove the realm from the router to
+			// prevent new clients from joining it.
 			delete(r.realms, name)
 			r.log.Printf("Removed realm: %s", name)
 		}
@@ -342,14 +343,15 @@ func (r *router) RemoveRealm(name wamp.URI) {
 	}
 	// wait until the atomic func has completed
 	<-sync
-	// if the realm was found within the router, close it outside of the atomic func while still blocking the caller
+	// if the realm was found within the router, close it outside of the atomic
+	// func while still blocking the caller
 	if ok {
 		realm.close()
 		r.log.Printf("Realm %s completed shutdown", name)
 	}
 }
 
-// addRealm perform the process of attempting to create and add a realm to this router.
+// addRealm attempts to create and add a realm to this router.
 //
 // this method should ONLY be called from within an atomic func
 func (r *router) addRealm(config *RealmConfig) (*realm, error) {

--- a/router/websocketserver.go
+++ b/router/websocketserver.go
@@ -9,6 +9,9 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
 
 	"github.com/gammazero/nexus/stdlog"
 	"github.com/gammazero/nexus/transport"
@@ -117,6 +120,29 @@ func (s *WebsocketServer) SetConfig(wsCfg transport.WebsocketConfig) {
 
 	s.EnableTrackingCookie = wsCfg.EnableTrackingCookie
 	s.EnableRequestCapture = wsCfg.EnableRequestCapture
+}
+
+// AllowOrigin sets the WebsocketServer.Upgrader.CheckOrigin to a function that
+// returns true if: the origin is not set, is equal to the request host, or
+// matches one of the allowed patterns.  A pattern is in the form of a shell
+// glob as described here: https://golang.org/pkg/path/filepath/#Match
+func (s *WebsocketServer) AllowOrigins(patterns []string) error {
+	if len(patterns) == 0 {
+		s.Upgrader.CheckOrigin = nil
+		return nil
+	}
+	for _, o := range patterns {
+		if _, err := filepath.Match(o, o); err != nil {
+			return fmt.Errorf("error allowing origin, %s: %s", err, o)
+		}
+		s.log.Println("Websocket server allowing origin matching:", o)
+	}
+	patsCopy := make([]string, len(patterns))
+	copy(patsCopy, patterns)
+	s.Upgrader.CheckOrigin = func(r *http.Request) bool {
+		return checkOrigin(patsCopy, r)
+	}
+	return nil
 }
 
 // ListenAndServe listens on the specified TCP address and starts a goroutine
@@ -271,4 +297,26 @@ func (s *WebsocketServer) handleWebsocket(conn *websocket.Conn, transportDetails
 	if err := s.router.AttachClient(peer, transportDetails); err != nil {
 		s.log.Println("Error attaching to router:", err)
 	}
+}
+
+// checkOrigin returns true if the origin is not set, is equal to the request
+// host, or matches one of the allowed patterns.
+func checkOrigin(patterns []string, r *http.Request) bool {
+	origin := r.Header["Origin"]
+	if len(origin) == 0 {
+		return true
+	}
+	u, err := url.Parse(origin[0])
+	if err != nil {
+		return false
+	}
+	if strings.EqualFold(u.Host, r.Host) {
+		return true
+	}
+	for i := range patterns {
+		if ok, _ := filepath.Match(patterns[i], u.Host); ok {
+			return true
+		}
+	}
+	return false
 }

--- a/router/websocketserver.go
+++ b/router/websocketserver.go
@@ -78,7 +78,13 @@ type WebsocketServer struct {
 }
 
 // NewWebsocketServer takes a router instance and creates a new websocket
-// server.  To run the websocket server, call one of the server's
+// server.
+//
+// Optional websocket server configuration can be set, after creating the
+// server instance, by setting WebsocketServer.Upgrader and WebsocketServer
+// members directly.
+//
+// To run the websocket server, call one of the server's
 // ListenAndServe methods:
 //
 //     s := NewWebsocketServer(r)

--- a/router/websocketserver.go
+++ b/router/websocketserver.go
@@ -29,6 +29,9 @@ type protocol struct {
 
 // WebsocketServer handles websocket connections.
 type WebsocketServer struct {
+	// Upgrader specifies parameters for upgrading an HTTP connection to a
+	// WebSocket connection.  See:
+	// https://godoc.org/github.com/gorilla/websocket#Upgrader
 	Upgrader *websocket.Upgrader
 
 	// Serializer for text frames.  Defaults to JSONSerializer.
@@ -41,8 +44,37 @@ type WebsocketServer struct {
 	protocols map[string]protocol
 	log       stdlog.StdLog
 
-	enableTrackingCookie bool
-	enableRequestCapture bool
+	// EnableTrackingCookie tells the server to send a random-value cookie to
+	// the websocket client.  A returning client may identify itself by sending
+	// a previously issued tracking cookie in a websocket request.  If a
+	// request header received by the server contains the tracking cookie, then
+	// the cookie is included in the HELLO and session details.  The new
+	// tracking cookie that gets sent to the client (the cookie to expect for
+	// subsequent connections) is also stored in HELLO and session details.
+	//
+	// The cookie from the request, and the next cookie to expect, are
+	// stored in the HELLO and session details, respectively, as:
+	//
+	//     Details.transport.auth.cookie|*http.Cookie
+	//     Details.transport.auth.nextcookie|*http.Cookie
+	//
+	// This information is available to auth/authz logic, and can be retrieved
+	// from details as follows:
+	//
+	//     req *http.Request
+	//     path := []string{"transport", "auth", "request"}
+	//     v, err := wamp.DictValue(details, path)
+	//     if err == nil {
+	//         req = v.(*http.Request)
+	//     }
+	//
+	// The "cookie" and "nextcookie" values are retrieved similarly.
+	EnableTrackingCookie bool
+	// EnableRequestCapture tells the server to include the upgrade HTTP
+	// request in the HELLO and session details.  It is stored in
+	// Details.transport.auth.request|*http.Request and is available to
+	// auth/authz logic.
+	EnableRequestCapture bool
 }
 
 // NewWebsocketServer takes a router instance and creates a new websocket
@@ -76,16 +108,15 @@ func NewWebsocketServer(r Router) *WebsocketServer {
 	return s
 }
 
-// SetConfig applies optional configuration settings to the websocket server.
+// DEPRICATED - Set WebsocketServer.Upgrader and WebsockServer.EnableX members
+// directly.
 func (s *WebsocketServer) SetConfig(wsCfg transport.WebsocketConfig) {
-	if wsCfg.EnableCompression {
-		s.Upgrader.EnableCompression = true
-		// Uncomment after https://github.com/gorilla/websocket/pull/342
-		//s.Upgrader.CompressionLevel = wsCfg.CompressionLevel
-		//s.Upgrader.EnableContextTakeover = wsCfg.EnableContextTakeover
-	}
-	s.enableTrackingCookie = wsCfg.EnableTrackingCookie
-	s.enableRequestCapture = wsCfg.EnableRequestCapture
+	s.Upgrader.EnableCompression = wsCfg.EnableCompression
+	// Uncomment after https://github.com/gorilla/websocket/pull/342
+	//s.Upgrader.AllowServerContextTakeover = wsCfg.EnableContextTakeover
+
+	s.EnableTrackingCookie = wsCfg.EnableTrackingCookie
+	s.EnableRequestCapture = wsCfg.EnableRequestCapture
 }
 
 // ListenAndServe listens on the specified TCP address and starts a goroutine
@@ -156,7 +187,7 @@ func (s *WebsocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// If tracking cookie is enabled, then read the tracking cookie from the
 	// request header, if it contains the cookie.  Generate a new tracking
 	// cookie for next time and put it in the response header.
-	if s.enableTrackingCookie {
+	if s.EnableTrackingCookie {
 		if authDict == nil {
 			authDict = wamp.Dict{}
 		}
@@ -182,7 +213,7 @@ func (s *WebsocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// If request capture is enabled, then the HTTP upgrade http.Request in the
 	// HELLO and session details as transport.auth details.request.
-	if s.enableRequestCapture {
+	if s.EnableRequestCapture {
 		if authDict == nil {
 			authDict = wamp.Dict{}
 		}

--- a/router/websocketserver_test.go
+++ b/router/websocketserver_test.go
@@ -37,12 +37,6 @@ func TestWSHandshakeJSON(t *testing.T) {
 
 	s := NewWebsocketServer(r)
 	s.Upgrader.EnableCompression = true
-	if err = s.AllowOrigins([]string{"foo.bar.com", "*.bar.net"}); err != nil {
-		t.Fatal(err)
-	}
-	if err = s.AllowOrigins([]string{"foo.bar.co["}); err == nil {
-		t.Fatal("Expected error")
-	}
 	closer, err := s.ListenAndServe(wsAddr)
 	if err != nil {
 		t.Fatal(err)

--- a/router/websocketserver_test.go
+++ b/router/websocketserver_test.go
@@ -37,6 +37,12 @@ func TestWSHandshakeJSON(t *testing.T) {
 
 	s := NewWebsocketServer(r)
 	s.Upgrader.EnableCompression = true
+	if err = s.AllowOrigins([]string{"foo.bar.com", "*.bar.net"}); err != nil {
+		t.Fatal(err)
+	}
+	if err = s.AllowOrigins([]string{"foo.bar.co["}); err == nil {
+		t.Fatal("Expected error")
+	}
 	closer, err := s.ListenAndServe(wsAddr)
 	if err != nil {
 		t.Fatal(err)

--- a/router/websocketserver_test.go
+++ b/router/websocketserver_test.go
@@ -36,14 +36,16 @@ func TestWSHandshakeJSON(t *testing.T) {
 	defer r.Close()
 
 	s := NewWebsocketServer(r)
-	wsCfg := transport.WebsocketConfig{EnableCompression: true}
-	s.SetConfig(wsCfg)
+	s.Upgrader.EnableCompression = true
 	closer, err := s.ListenAndServe(wsAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer closer.Close()
 
+	wsCfg := transport.WebsocketConfig{
+		EnableCompression: true,
+	}
 	client, err := transport.ConnectWebsocketPeer(
 		fmt.Sprintf("ws://%s/", wsAddr), serialize.JSON, nil, nil, r.Logger(), &wsCfg)
 	if err != nil {

--- a/transport/websocketpeer.go
+++ b/transport/websocketpeer.go
@@ -20,52 +20,17 @@ type WebsocketConfig struct {
 	// When configuring client: requests compression, used if server allows
 	EnableCompression     bool `json:"enable_compression"`
 	EnableContextTakeover bool `json:"enable_context_takeover"`
-	CompressionLevel      int  `json:"compression_level"`
 
-	// For WebsocketServer configuration only.  These options are configured
-	// for the router by passing WebsocketConfig to
-	// WebsocketServer.SetConfig().
-	//
-	// EnableTrackingCookie tells the server to send a random-value cookie to
-	// the websocket client.  A returning client may identify itself by sending
-	// a previously issued tracking cookie in a websocket request.  If a
-	// request header received by the server contains the tracking cookie, then
-	// the cookie is included in the HELLO and session details.  The new
-	// tracking cookie that gets sent to the client (the cookie to expect for
-	// subsequent connections) is also stored in HELLO and session details.
-	//
-	// The cookie from the request, and the next cookie to expect, are
-	// stored in the HELLO and session details, respectively, as:
-	//
-	//     Details.transport.auth.cookie|*http.Cookie
-	//     Details.transport.auth.nextcookie|*http.Cookie
-	//
-	// This information is available to auth/authz logic, and can be retrieved
-	// from details as follows:
-	//
-	//     req *http.Request
-	//     path := []string{"transport", "auth", "request"}
-	//     v, err := wamp.DictValue(details, path)
-	//     if err == nil {
-	//         req = v.(*http.Request)
-	//     }
-	//
-	// The "cookie" and "nextcookie" values are retrieved similarly.
-	//
-	// EnableRequestCapture tells the server to include the upgrade HTTP
-	// request in the HELLO and session details.  It is stored in
-	// Details.transport.auth.request|*http.Request and is available to
-	// auth/authz logic.
-	EnableTrackingCookie bool `json:"enable_tracking_cookie"`
-	EnableRequestCapture bool `json:"enable_request_capture"`
-
-	// For websocket client configuration only
-	//
 	// If provided when configuring websocket client, cookies from server are
 	// put in here.  This allows cookies to be stored and then sent back to the
 	// server in subsequent websocket connections.  Cookies may be used to
 	// identify returning clients, and can be used to authenticate clients.
 	Jar http.CookieJar
+
+	// Depricated server config options.
+	// See: https://godoc.org/github.com/gammazero/nexus/router#WebsocketServer
+	EnableTrackingCookie bool `json:"enable_tracking_cookie"`
+	EnableRequestCapture bool `json:"enable_request_capture"`
 }
 
 // websocketPeer implements the Peer interface, connecting the Send and Recv
@@ -99,8 +64,9 @@ const (
 
 type DialFunc func(network, addr string) (net.Conn, error)
 
-// ConnectWebsocketPeer creates a new websocketPeer with the specified config,
-// and connects it to the websocket server at the specified URL.
+// ConnectWebsocketPeer creates a new websocket client with the specified
+// config, connects the client to the websocket server at the specified URL,
+// and returns the connected websocket peer.
 func ConnectWebsocketPeer(url string, serialization serialize.Serialization, tlsConfig *tls.Config, dial DialFunc, logger stdlog.StdLog, wsCfg *WebsocketConfig) (wamp.Peer, error) {
 	var (
 		protocol    string
@@ -128,11 +94,10 @@ func ConnectWebsocketPeer(url string, serialization serialize.Serialization, tls
 		NetDial:         dial,
 	}
 	if wsCfg != nil {
-		dialer.EnableCompression = wsCfg.EnableCompression
-		//dialer.EnableContextTakeover = wsCfg.EnableContextTakeover
-		//dialer.CompressionLevel = wsCfg.CompressionLevel
-
 		dialer.Jar = wsCfg.Jar
+		dialer.EnableCompression = true
+		// Uncomment after https://github.com/gorilla/websocket/pull/342
+		//dialer.AllowClientContextTakeover = wsCfg.EnableContextTakeover
 	}
 
 	conn, _, err := dialer.Dial(url, nil)

--- a/transport/websocketpeer.go
+++ b/transport/websocketpeer.go
@@ -14,10 +14,9 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+// WebsockerConfig is used to provide configuration client websocker settings.
 type WebsocketConfig struct {
-	// Enable per message write compression.
-	// When configuring server: allows compression, used if clients request
-	// When configuring client: requests compression, used if server allows
+	// Request per message write compression, if allowed by server.
 	EnableCompression     bool `json:"enable_compression"`
 	EnableContextTakeover bool `json:"enable_context_takeover"`
 


### PR DESCRIPTION
Fix #93 

- Add code to nexusd to allow websocket connection with different origin headers.
- Deprecate previous websocket server configuration method, as this allowed multiple ways to set `WebsocketServer.Upgrader` settings, and mixed server and client configuration.
- Fix `nexusd.json` configuration file