### PR TITLE
Implement CBOR serialization, replace JSON serializer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ test:
 	go test -race ./aat -scheme=unix
 	go test ./aat -scheme=ws -serialize=msgpack
 	go test ./aat -scheme=tcp -serialize=msgpack
+	go test ./aat -scheme=ws -serialize=cbor
+	go test ./aat -scheme=tcp -serialize=cbor
 	go test ./aat -scheme=wss
 	go test ./aat -scheme=tcps
 

--- a/aat/main_test.go
+++ b/aat/main_test.go
@@ -77,11 +77,11 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&scheme, "scheme", "",
 		"-scheme=[ws, wss, tcp, tcps, unix] or none for local (in-process)")
 	flag.StringVar(&serType, "serialize", "",
-		"-serialize[json, msgpack] default is json")
+		"-serialize[json, msgpack, cbor] default is json")
 	flag.BoolVar(&compress, "compress", false, "enable compression")
 	flag.Parse()
 
-	if serType != "" && serType != "json" && serType != "msgpack" {
+	if serType != "" && serType != "json" && serType != "msgpack" && serType != "cbor" {
 		fmt.Fprintln(os.Stderr, "invalid serialize value")
 		flag.Usage()
 		os.Exit(1)
@@ -241,6 +241,8 @@ func connectClientCfg(cfg client.ClientConfig) (*client.Client, error) {
 		cfg.Serialization = serialize.JSON
 	case "msgpack":
 		cfg.Serialization = serialize.MSGPACK
+	case "cbor":
+		cfg.Serialization = serialize.CBOR
 	}
 	cfg.Logger = cliLogger
 

--- a/client/client.go
+++ b/client/client.go
@@ -78,6 +78,7 @@ type ClientConfig struct {
 const (
 	JSON    = serialize.JSON
 	MSGPACK = serialize.MSGPACK
+	CBOR    = serialize.CBOR
 )
 
 // Features supported by nexus client.

--- a/router/websocketserver.go
+++ b/router/websocketserver.go
@@ -20,6 +20,7 @@ import (
 const (
 	jsonWebsocketProtocol    = "wamp.2.json"
 	msgpackWebsocketProtocol = "wamp.2.msgpack"
+	cborWebsocketProtocol    = "wamp.2.cbor"
 )
 
 type protocol struct {
@@ -110,6 +111,8 @@ func NewWebsocketServer(r Router) *WebsocketServer {
 		&serialize.JSONSerializer{})
 	s.addProtocol(msgpackWebsocketProtocol, websocket.BinaryMessage,
 		&serialize.MessagePackSerializer{})
+	s.addProtocol(cborWebsocketProtocol, websocket.BinaryMessage,
+		&serialize.CBORSerializer{})
 
 	return s
 }
@@ -264,6 +267,9 @@ func (s *WebsocketServer) handleWebsocket(conn *websocket.Conn, transportDetails
 			payloadType = websocket.TextMessage
 		case msgpackWebsocketProtocol:
 			serializer = &serialize.MessagePackSerializer{}
+			payloadType = websocket.BinaryMessage
+		case cborWebsocketProtocol:
+			serializer = &serialize.CBORSerializer{}
 			payloadType = websocket.BinaryMessage
 		default:
 			conn.Close()

--- a/transport/rawsocketpeer.go
+++ b/transport/rawsocketpeer.go
@@ -38,6 +38,8 @@ const (
 	// Serializers
 	rawsocketJSON    = 1
 	rawsocketMsgpack = 2
+	// compatibility with crossbar.io router.
+	rawsocketCBOR    = 3
 
 	// RawSocket header ID.
 	magic = 0x7f
@@ -369,6 +371,8 @@ func clientHandshake(conn net.Conn, logger stdlog.StdLog, protocol byte, recvLim
 		serializer = &serialize.JSONSerializer{}
 	case rawsocketMsgpack:
 		serializer = &serialize.MessagePackSerializer{}
+	case rawsocketCBOR:
+		serializer = &serialize.CBORSerializer{}
 	}
 
 	sendLimit := byteToLength(buf[1] >> 4)
@@ -400,6 +404,8 @@ func serverHandshake(conn net.Conn, logger stdlog.StdLog, recvLimit int) (*rawSo
 		serializer = &serialize.JSONSerializer{}
 	case rawsocketMsgpack:
 		serializer = &serialize.MessagePackSerializer{}
+	case rawsocketCBOR:
+		serializer = &serialize.CBORSerializer{}
 	default:
 		conn.Write([]byte{magic, byte(0x1 << 4), 0, 0})
 		return nil, errors.New("serializer unsupported")
@@ -470,6 +476,8 @@ func getProtoByte(serialization serialize.Serialization) (byte, error) {
 		return rawsocketJSON, nil
 	case serialize.MSGPACK:
 		return rawsocketMsgpack, nil
+	case serialize.CBOR:
+		return rawsocketCBOR, nil
 	default:
 		return 0, errors.New("serialization not supported by rawsocket")
 	}

--- a/transport/serialize/cborserializer.go
+++ b/transport/serialize/cborserializer.go
@@ -1,0 +1,45 @@
+package serialize
+
+import (
+	"errors"
+
+	"github.com/gammazero/nexus/wamp"
+	"github.com/ugorji/go/codec"
+)
+
+// CBORSerializer is an implementation of Serializer that handles
+// serializing and deserializing cbor encoded payloads.
+type CBORSerializer struct{}
+
+// Serialize encodes a Message into a cbor payload.
+func (s *CBORSerializer) Serialize(msg wamp.Message) ([]byte, error) {
+	var b []byte
+	cbh := &codec.CborHandle{
+
+	}
+	return b, codec.NewEncoderBytes(&b, cbh).Encode(
+		msgToList(msg))
+}
+
+// Deserialize decodes a cbor payload into a Message.
+func (s *CBORSerializer) Deserialize(data []byte) (wamp.Message, error) {
+	var v []interface{}
+	cbh := &codec.CborHandle{
+
+	}
+	err := codec.NewDecoderBytes(data, cbh).Decode(&v)
+	if err != nil {
+		return nil, err
+	}
+	if len(v) == 0 {
+		return nil, errors.New("invalid message")
+	}
+
+	// cbor deserializer gives us an uint64 instead of an int64, whyever
+	// it doesn't matter here, because valid values are only within an 8bit range.
+	typ, ok := v[0].(uint64)
+	if !ok {
+		return nil, errors.New("unsupported message format")
+	}
+	return listToMsg(wamp.MessageType(typ), v)
+}

--- a/transport/serialize/jsonserializer.go
+++ b/transport/serialize/jsonserializer.go
@@ -6,28 +6,40 @@ import (
 	"errors"
 
 	"github.com/gammazero/nexus/wamp"
+	"github.com/ugorji/go/codec"
 )
 
-// JSONSerializer is an implementation of Serializer that handles serializing
-// and deserializing JSON encoded payloads.
+// JSONSerializer is an implementation of Serializer that handles
+// serializing and deserializing json encoded payloads.
 type JSONSerializer struct{}
 
-// Serialize encodes a message into a JSON payload.
+// Serialize encodes a Message into a json payload.
 func (s *JSONSerializer) Serialize(msg wamp.Message) ([]byte, error) {
-	return json.Marshal(msgToList(msg))
+	var b []byte
+	jsh := &codec.JsonHandle{
+
+	}
+	return b, codec.NewEncoderBytes(&b, jsh).Encode(
+		msgToList(msg))
 }
 
-// Deserialize decodes a JSON payload into a message.
+// Deserialize decodes a json payload into a Message.
 func (s *JSONSerializer) Deserialize(data []byte) (wamp.Message, error) {
 	var v []interface{}
-	if err := json.Unmarshal(data, &v); err != nil {
+	jsh := &codec.JsonHandle{
+
+	}
+	err := codec.NewDecoderBytes(data, jsh).Decode(&v)
+	if err != nil {
 		return nil, err
 	}
 	if len(v) == 0 {
 		return nil, errors.New("invalid message")
 	}
 
-	typ, ok := v[0].(float64)
+	// json deserializer gives us an uint64 instead of an int64, whyever
+	// it doesn't matter here, because valid values are only within an 8bit range.
+	typ, ok := v[0].(uint64)
 	if !ok {
 		return nil, errors.New("unsupported message format")
 	}

--- a/transport/serialize/jsonserializer.go
+++ b/transport/serialize/jsonserializer.go
@@ -2,7 +2,6 @@ package serialize
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 
 	"github.com/gammazero/nexus/wamp"
@@ -57,12 +56,15 @@ type BinaryData []byte
 
 func (b BinaryData) MarshalJSON() ([]byte, error) {
 	s := base64.StdEncoding.EncodeToString([]byte(b))
-	return json.Marshal("\x00" + s)
+	var out []byte
+	jsh := &codec.JsonHandle{}
+	return out, codec.NewEncoderBytes(&out, jsh).Encode("\x00" + s)
 }
 
 func (b *BinaryData) UnmarshalJSON(v []byte) error {
 	var s string
-	err := json.Unmarshal(v, &s)
+	jsh := &codec.JsonHandle{}
+	err := codec.NewDecoderBytes(v, jsh).Decode(&s)
 	if err != nil {
 		return nil
 	}

--- a/transport/serialize/serializer.go
+++ b/transport/serialize/serializer.go
@@ -19,6 +19,8 @@ const (
 	JSON Serialization = iota
 	// Use msgpack-encoded strings as a payload.
 	MSGPACK
+	// Use CBOR encoding as a payload
+	CBOR
 )
 
 // Serialization indicates the data serialization format used in a WAMP session

--- a/transport/serialize/serializer_test.go
+++ b/transport/serialize/serializer_test.go
@@ -79,6 +79,62 @@ func TestJSONDeserialize(t *testing.T) {
 	}
 }
 
+func TestCBORSerialize(t *testing.T) {
+	details := detailRolesFeatures()
+	hello := &wamp.Hello{Realm: "nexus.realm", Details: details}
+
+	s := &CBORSerializer{}
+	b, err := s.Serialize(hello)
+	if err != nil {
+		t.Fatal("Serialization error: ", err)
+	}
+	if len(b) == 0 {
+		t.Fatal("no serialized data")
+	}
+
+	msg, err := s.Deserialize(b)
+	if err != nil {
+		t.Fatal("desrialization error: ", err)
+	}
+	if msg.MessageType() != wamp.HELLO {
+		t.Fatal("desrialization to wrong message type: ", msg.MessageType())
+	}
+	if !hasFeature(hello.Details, "publisher", "subscriber_blackwhite_listing") {
+		t.Fatal("did not deserialize message details")
+	}
+}
+
+func CBORDeserialize(t *testing.T) {
+	s := &CBORSerializer{}
+
+	// this is the CBOR representation of the message above
+	data := []byte{
+		0x83, 0x01, 0x6b, 0x6e, 0x65, 0x78, 0x75, 0x73, 0x2e, 0x72, 0x65, 0x61,
+		0x6c, 0x6d, 0xa1, 0x65, 0x72, 0x6f, 0x6c, 0x65, 0x73, 0xa4, 0x6a, 0x73,
+		0x75, 0x62, 0x73, 0x63, 0x72, 0x69, 0x62, 0x65, 0x72, 0xa0, 0x66, 0x63,
+		0x61, 0x6c, 0x6c, 0x65, 0x65, 0xa0, 0x66, 0x63, 0x61, 0x6c, 0x6c, 0x65,
+		0x72, 0xa0, 0x69, 0x70, 0x75, 0x62, 0x6c, 0x69, 0x73, 0x68, 0x65, 0x72,
+		0xa1, 0x68, 0x66, 0x65, 0x61, 0x74, 0x75, 0x72, 0x65, 0x73, 0xa1, 0x78,
+		0x1d, 0x73, 0x75, 0x62, 0x73, 0x63, 0x72, 0x69, 0x62, 0x65, 0x72, 0x5f,
+		0x62, 0x6c, 0x61, 0x63, 0x6b, 0x77, 0x68, 0x69, 0x74, 0x65, 0x5f, 0x6c,
+		0x69, 0x73, 0x74, 0x69, 0x6e, 0x67, 0xf5,
+	}
+	details := detailRolesFeatures()
+	expect := &wamp.Hello{Realm: "nexus.realm", Details: details}
+
+	msg, err := s.Deserialize(data)
+	if err != nil {
+		t.Fatalf("Error decoding good data: %s, %x", err, data)
+	}
+	if msg.MessageType() != expect.MessageType() {
+		t.Fatalf("Incorrect message type: have %s, want %s", msg.MessageType(),
+			expect.MessageType())
+	}
+	if !reflect.DeepEqual(msg, expect) {
+		t.Fatalf("got %+v, expected %+v", msg, expect)
+	}
+}
+
 func TestMessagePackSerialize(t *testing.T) {
 	hello := &wamp.Hello{Realm: "nexus.realm", Details: detailRolesFeatures()}
 

--- a/transport/websocketpeer.go
+++ b/transport/websocketpeer.go
@@ -14,22 +14,58 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// WebsockerConfig is used to provide configuration client websocker settings.
 type WebsocketConfig struct {
-	// Request per message write compression, if allowed by server.
+	// Enable per message write compression.
+	// When configuring server: allows compression, used if clients request
+	// When configuring client: requests compression, used if server allows
 	EnableCompression     bool `json:"enable_compression"`
 	EnableContextTakeover bool `json:"enable_context_takeover"`
+	CompressionLevel      int  `json:"compression_level"`
 
+	// For WebsocketServer configuration only.  These options are configured
+	// for the router by passing WebsocketConfig to
+	// WebsocketServer.SetConfig().
+	//
+	// EnableTrackingCookie tells the server to send a random-value cookie to
+	// the websocket client.  A returning client may identify itself by sending
+	// a previously issued tracking cookie in a websocket request.  If a
+	// request header received by the server contains the tracking cookie, then
+	// the cookie is included in the HELLO and session details.  The new
+	// tracking cookie that gets sent to the client (the cookie to expect for
+	// subsequent connections) is also stored in HELLO and session details.
+	//
+	// The cookie from the request, and the next cookie to expect, are
+	// stored in the HELLO and session details, respectively, as:
+	//
+	//     Details.transport.auth.cookie|*http.Cookie
+	//     Details.transport.auth.nextcookie|*http.Cookie
+	//
+	// This information is available to auth/authz logic, and can be retrieved
+	// from details as follows:
+	//
+	//     req *http.Request
+	//     path := []string{"transport", "auth", "request"}
+	//     v, err := wamp.DictValue(details, path)
+	//     if err == nil {
+	//         req = v.(*http.Request)
+	//     }
+	//
+	// The "cookie" and "nextcookie" values are retrieved similarly.
+	//
+	// EnableRequestCapture tells the server to include the upgrade HTTP
+	// request in the HELLO and session details.  It is stored in
+	// Details.transport.auth.request|*http.Request and is available to
+	// auth/authz logic.
+	EnableTrackingCookie bool `json:"enable_tracking_cookie"`
+	EnableRequestCapture bool `json:"enable_request_capture"`
+
+	// For websocket client configuration only
+	//
 	// If provided when configuring websocket client, cookies from server are
 	// put in here.  This allows cookies to be stored and then sent back to the
 	// server in subsequent websocket connections.  Cookies may be used to
 	// identify returning clients, and can be used to authenticate clients.
 	Jar http.CookieJar
-
-	// Depricated server config options.
-	// See: https://godoc.org/github.com/gammazero/nexus/router#WebsocketServer
-	EnableTrackingCookie bool `json:"enable_tracking_cookie"`
-	EnableRequestCapture bool `json:"enable_request_capture"`
 }
 
 // websocketPeer implements the Peer interface, connecting the Send and Recv
@@ -56,6 +92,7 @@ const (
 	// modes:
 	jsonWebsocketProtocol    = "wamp.2.json"
 	msgpackWebsocketProtocol = "wamp.2.msgpack"
+	cborWebsocketProtocol    = "wamp.2.cbor"
 
 	outQueueSize = 16
 	ctrlTimeout  = 5 * time.Second
@@ -63,9 +100,8 @@ const (
 
 type DialFunc func(network, addr string) (net.Conn, error)
 
-// ConnectWebsocketPeer creates a new websocket client with the specified
-// config, connects the client to the websocket server at the specified URL,
-// and returns the connected websocket peer.
+// ConnectWebsocketPeer creates a new websocketPeer with the specified config,
+// and connects it to the websocket server at the specified URL.
 func ConnectWebsocketPeer(url string, serialization serialize.Serialization, tlsConfig *tls.Config, dial DialFunc, logger stdlog.StdLog, wsCfg *WebsocketConfig) (wamp.Peer, error) {
 	var (
 		protocol    string
@@ -82,6 +118,10 @@ func ConnectWebsocketPeer(url string, serialization serialize.Serialization, tls
 		protocol = msgpackWebsocketProtocol
 		payloadType = websocket.BinaryMessage
 		serializer = &serialize.MessagePackSerializer{}
+	case serialize.CBOR:
+		protocol = cborWebsocketProtocol
+		payloadType = websocket.BinaryMessage
+		serializer = &serialize.CBORSerializer{}
 	default:
 		return nil, fmt.Errorf("unsupported serialization: %v", serialization)
 	}
@@ -93,10 +133,11 @@ func ConnectWebsocketPeer(url string, serialization serialize.Serialization, tls
 		NetDial:         dial,
 	}
 	if wsCfg != nil {
+		dialer.EnableCompression = wsCfg.EnableCompression
+		//dialer.EnableContextTakeover = wsCfg.EnableContextTakeover
+		//dialer.CompressionLevel = wsCfg.CompressionLevel
+
 		dialer.Jar = wsCfg.Jar
-		dialer.EnableCompression = true
-		// Uncomment after https://github.com/gorilla/websocket/pull/342
-		//dialer.AllowClientContextTakeover = wsCfg.EnableContextTakeover
 	}
 
 	conn, _, err := dialer.Dial(url, nil)


### PR DESCRIPTION
This commit replaces the golang `encoding/json` by `ugorji/co/codec` for speed.
Additionally, I implemented a CBOR serializer and deserializer and added tests
to ensure it's working as expected.

Binary compatibility to other routers such as crossbar.io should be given, since
the implementation is using the default cbor name.