### PR TITLE
Change mapType to be deserialized to map[string]interface{}

### DIFF
--- a/transport/serialize/cborserializer.go
+++ b/transport/serialize/cborserializer.go
@@ -2,6 +2,7 @@ package serialize
 
 import (
 	"errors"
+	"reflect"
 
 	"github.com/gammazero/nexus/wamp"
 	"github.com/ugorji/go/codec"
@@ -15,6 +16,7 @@ type CBORSerializer struct{}
 func (s *CBORSerializer) Serialize(msg wamp.Message) ([]byte, error) {
 	var b []byte
 	cbh := &codec.CborHandle{}
+	cbh.MapType = reflect.TypeOf(map[string]interface{}(nil))
 	return b, codec.NewEncoderBytes(&b, cbh).Encode(msgToList(msg))
 }
 
@@ -22,6 +24,7 @@ func (s *CBORSerializer) Serialize(msg wamp.Message) ([]byte, error) {
 func (s *CBORSerializer) Deserialize(data []byte) (wamp.Message, error) {
 	var v []interface{}
 	cbh := &codec.CborHandle{}
+	cbh.MapType = reflect.TypeOf(map[string]interface{}(nil))
 	err := codec.NewDecoderBytes(data, cbh).Decode(&v)
 	if err != nil {
 		return nil, err

--- a/transport/serialize/jsonserializer.go
+++ b/transport/serialize/jsonserializer.go
@@ -3,6 +3,7 @@ package serialize
 import (
 	"encoding/base64"
 	"errors"
+	"reflect"
 
 	"github.com/gammazero/nexus/wamp"
 	"github.com/ugorji/go/codec"
@@ -16,6 +17,7 @@ type JSONSerializer struct{}
 func (s *JSONSerializer) Serialize(msg wamp.Message) ([]byte, error) {
 	var b []byte
 	jsh := &codec.JsonHandle{}
+	jsh.MapType = reflect.TypeOf(map[string]interface{}(nil))
 	return b, codec.NewEncoderBytes(&b, jsh).Encode(msgToList(msg))
 }
 
@@ -23,6 +25,7 @@ func (s *JSONSerializer) Serialize(msg wamp.Message) ([]byte, error) {
 func (s *JSONSerializer) Deserialize(data []byte) (wamp.Message, error) {
 	var v []interface{}
 	jsh := &codec.JsonHandle{}
+	jsh.MapType = reflect.TypeOf(map[string]interface{}(nil))
 	err := codec.NewDecoderBytes(data, jsh).Decode(&v)
 	if err != nil {
 		return nil, err

--- a/transport/serialize/msgpackserializer.go
+++ b/transport/serialize/msgpackserializer.go
@@ -2,6 +2,7 @@ package serialize
 
 import (
 	"errors"
+	"reflect"
 
 	"github.com/gammazero/nexus/wamp"
 	"github.com/ugorji/go/codec"
@@ -17,6 +18,7 @@ func (s *MessagePackSerializer) Serialize(msg wamp.Message) ([]byte, error) {
 	mph := &codec.MsgpackHandle{
 		RawToString: true,
 	}
+	mph.MapType = reflect.TypeOf(map[string]interface{}(nil))
 	return b, codec.NewEncoderBytes(&b, mph).Encode(
 		msgToList(msg))
 }
@@ -27,6 +29,7 @@ func (s *MessagePackSerializer) Deserialize(data []byte) (wamp.Message, error) {
 	mph := &codec.MsgpackHandle{
 		RawToString: true,
 	}
+	mph.MapType = reflect.TypeOf(map[string]interface{}(nil))
 	err := codec.NewDecoderBytes(data, mph).Decode(&v)
 	if err != nil {
 		return nil, err

--- a/transport/serialize/serializer_test.go
+++ b/transport/serialize/serializer_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/gammazero/nexus/wamp"
 )
 
@@ -289,10 +290,13 @@ func TestMsgToList(t *testing.T) {
 
 func TestMsgPackToJSON(t *testing.T) {
 	arg := "this is a test"
+	arg2 := map[string]interface{}{
+		"hello": "world",
+	}
 	pub := &wamp.Publish{
 		Request:   123,
 		Topic:     "msgpack.to.json",
-		Arguments: wamp.List{arg},
+		Arguments: wamp.List{arg, arg2},
 	}
 	ms := &MessagePackSerializer{}
 	b, err := ms.Serialize(pub)
@@ -338,12 +342,17 @@ func TestMsgPackToJSON(t *testing.T) {
 	if e2.Publication != wamp.ID(123) {
 		t.Fatal("JSON deserialization error: wrong publication ID")
 	}
-	if len(e2.Arguments) != 1 {
+	if len(e2.Arguments) != 2 {
 		t.Fatal("JSON deserialization error: wrong number of arguments")
 	}
 	a, _ := wamp.AsString(e2.Arguments[0])
 	if string(a) != arg {
 		t.Fatal("JSON deserialize error: did not get argument, got:", e2.Arguments[0])
+	}
+	arr, ok := e2.Arguments[1].(map[string]interface{})
+	if !ok || !reflect.DeepEqual(arr, arg2) {
+		spew.Dump(e2.Arguments[1])
+		t.Fatal("JSON deserialize error, expected dict, got: ", e2.Arguments[1])
 	}
 }
 


### PR DESCRIPTION
This fixes #97 by setting the type of the keysof the deserialized maps to string.
Strings as keys are a safe default, since the JSONEncoder can handle them.

Please note that this is an api-breaking change for some applications, such as those
supporting only msgpack and checking explicitly against map[interface{}]interface{}
For JSON clients, no difference should be seen.

I also added the case to the MsgPack to JSON serialization test.