### PR TITLE
Configurable keep-alive for websocker server

### DIFF
--- a/examples/server/server.go
+++ b/examples/server/server.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"path"
+	"time"
 
 	"github.com/gammazero/nexus/router"
 	"github.com/gammazero/nexus/wamp"
@@ -45,10 +46,12 @@ func main() {
 
 	// Create websocket server.
 	wss := router.NewWebsocketServer(nxr)
-	// Enable websocket compression, which will be used if clients request it.
+	// Enable websocket compression, which is used if clients request it.
 	wss.Upgrader.EnableCompression = true
 	// Configure server to send and look for client tracking cookie.
 	wss.EnableTrackingCookie = true
+	// Set keep-alive period to 30 seconds.
+	wss.KeepAlive = 30 * time.Second
 
 	// Create rawsocket server.
 	rss := router.NewRawSocketServer(nxr, 0, 0)

--- a/router/rawsocketserver.go
+++ b/router/rawsocketserver.go
@@ -17,16 +17,16 @@ type RawSocketServer struct {
 
 	log       stdlog.StdLog
 	recvLimit int
-	keepalive time.Duration
+	keepAlive time.Duration
 }
 
 // NewRawSocketServer takes a router instance and creates a new socket server.
-func NewRawSocketServer(r Router, recvLimit int, keepalive time.Duration) *RawSocketServer {
+func NewRawSocketServer(r Router, recvLimit int, keepAlive time.Duration) *RawSocketServer {
 	return &RawSocketServer{
 		router:    r,
 		log:       r.Logger(),
 		recvLimit: recvLimit,
-		keepalive: keepalive,
+		keepAlive: keepAlive,
 	}
 }
 
@@ -87,9 +87,9 @@ func (s *RawSocketServer) requestHandler(l net.Listener) {
 			return
 		}
 		if tcpConn, ok := conn.(*net.TCPConn); ok {
-			if s.keepalive != 0 {
+			if s.keepAlive != 0 {
 				tcpConn.SetKeepAlive(true)
-				tcpConn.SetKeepAlivePeriod(s.keepalive)
+				tcpConn.SetKeepAlivePeriod(s.keepAlive)
 			} else {
 				tcpConn.SetKeepAlive(false)
 			}


### PR DESCRIPTION
To configure websocket server keep-alive, set `WebsocketServer.KeepAlive` before calling `ListenAndServe()`:

```go
wsServer := router.NewWebsocketServer(nxsRouter)
// Set keep-alive period to 30 seconds.
wsServer.KeepAlive = 30 * time.Second
// Run websocket server.
wsCloser, err := wsServer.ListenAndServe(wsAddr)
```
