### PR TITLE
Add more fields when disclosing publisher or caller

### DIFF
--- a/router/broker.go
+++ b/router/broker.go
@@ -457,7 +457,7 @@ func (b *Broker) pubEvent(pub *wamp.Session, msg *wamp.Publish, pubID wamp.ID, s
 		}
 
 		if disclose && sub.HasFeature(roleSub, featurePubIdent) {
-			details[rolePub] = pub.ID
+			disclosePublisher(pub, details)
 		}
 
 		// TODO: Handle publication trust levels
@@ -561,4 +561,20 @@ func (b *Broker) trySend(sess *wamp.Session, msg wamp.Message) bool {
 		return false
 	}
 	return true
+}
+
+func disclosePublisher(pub *wamp.Session, details wamp.Dict) {
+	details[rolePub] = pub.ID
+	features := []string{
+		"authrole",
+		"authid",
+		"authmethod",
+		"authextra",
+	}
+	for _, f := range features {
+		val, ok := pub.Details[f]
+		if ok {
+			details[fmt.Sprintf("%s_%s", rolePub, f)] = val
+		}
+	}
 }

--- a/router/broker.go
+++ b/router/broker.go
@@ -568,8 +568,6 @@ func disclosePublisher(pub *wamp.Session, details wamp.Dict) {
 	features := []string{
 		"authrole",
 		"authid",
-		"authmethod",
-		"authextra",
 	}
 	for _, f := range features {
 		val, ok := pub.Details[f]

--- a/router/dealer.go
+++ b/router/dealer.go
@@ -582,7 +582,7 @@ func (d *Dealer) call(caller *wamp.Session, msg *wamp.Call) {
 	// If the callee has requested disclosure of caller identity when the
 	// registration was created, and this was allowed by the dealer.
 	if reg.disclose {
-		details[roleCaller] = caller.ID
+		discloseCaller(caller, details)
 	} else {
 		// A Caller MAY request the disclosure of its identity (its WAMP
 		// session ID) to endpoints of a routed call.  This is indicated by the
@@ -598,7 +598,7 @@ func (d *Dealer) call(caller *wamp.Session, msg *wamp.Call) {
 				})
 			}
 			if callee.HasFeature(roleCallee, featureCallerIdent) {
-				details[roleCaller] = caller.ID
+				discloseCaller(caller, details)
 			}
 		}
 	}
@@ -1092,4 +1092,20 @@ func (d *Dealer) trySend(sess *wamp.Session, msg wamp.Message) bool {
 		return false
 	}
 	return true
+}
+
+func discloseCaller(caller *wamp.Session, details wamp.Dict) {
+	details[roleCaller] = caller.ID
+	features := []string{
+		"authrole",
+		"authid",
+		"authmethod",
+		"authextra",
+	}
+	for _, f := range features {
+		val, ok := caller.Details[f]
+		if ok {
+			details[fmt.Sprintf("%s_%s", roleCaller, f)] = val
+		}
+	}
 }

--- a/router/dealer.go
+++ b/router/dealer.go
@@ -1099,8 +1099,6 @@ func discloseCaller(caller *wamp.Session, details wamp.Dict) {
 	features := []string{
 		"authrole",
 		"authid",
-		"authmethod",
-		"authextra",
 	}
 	for _, f := range features {
 		val, ok := caller.Details[f]


### PR DESCRIPTION
This further improves the compatibility to crossbar.io by disclosing
caller_authid, caller_authrole, caller_authmethod and caller_authextra if set.

For pubsub, the same properties are exposed.