### PR TITLE
Messagepack extensions

### DIFF
--- a/transport/serialize/cborserializer.go
+++ b/transport/serialize/cborserializer.go
@@ -8,6 +8,13 @@ import (
 	"github.com/ugorji/go/codec"
 )
 
+var ch *codec.CborHandle
+
+func init() {
+	ch = &codec.CborHandle{}
+	ch.MapType = reflect.TypeOf(map[string]interface{}(nil))
+}
+
 // CBORSerializer is an implementation of Serializer that handles
 // serializing and deserializing cbor encoded payloads.
 type CBORSerializer struct{}
@@ -15,17 +22,13 @@ type CBORSerializer struct{}
 // Serialize encodes a Message into a cbor payload.
 func (s *CBORSerializer) Serialize(msg wamp.Message) ([]byte, error) {
 	var b []byte
-	cbh := &codec.CborHandle{}
-	cbh.MapType = reflect.TypeOf(map[string]interface{}(nil))
-	return b, codec.NewEncoderBytes(&b, cbh).Encode(msgToList(msg))
+	return b, codec.NewEncoderBytes(&b, ch).Encode(msgToList(msg))
 }
 
 // Deserialize decodes a cbor payload into a Message.
 func (s *CBORSerializer) Deserialize(data []byte) (wamp.Message, error) {
 	var v []interface{}
-	cbh := &codec.CborHandle{}
-	cbh.MapType = reflect.TypeOf(map[string]interface{}(nil))
-	err := codec.NewDecoderBytes(data, cbh).Decode(&v)
+	err := codec.NewDecoderBytes(data, ch).Decode(&v)
 	if err != nil {
 		return nil, err
 	}

--- a/transport/serialize/jsonserializer.go
+++ b/transport/serialize/jsonserializer.go
@@ -9,6 +9,13 @@ import (
 	"github.com/ugorji/go/codec"
 )
 
+var jh *codec.JsonHandle
+
+func init() {
+	jh = &codec.JsonHandle{}
+	jh.MapType = reflect.TypeOf(map[string]interface{}(nil))
+}
+
 // JSONSerializer is an implementation of Serializer that handles
 // serializing and deserializing json encoded payloads.
 type JSONSerializer struct{}
@@ -16,17 +23,13 @@ type JSONSerializer struct{}
 // Serialize encodes a Message into a json payload.
 func (s *JSONSerializer) Serialize(msg wamp.Message) ([]byte, error) {
 	var b []byte
-	jsh := &codec.JsonHandle{}
-	jsh.MapType = reflect.TypeOf(map[string]interface{}(nil))
-	return b, codec.NewEncoderBytes(&b, jsh).Encode(msgToList(msg))
+	return b, codec.NewEncoderBytes(&b, jh).Encode(msgToList(msg))
 }
 
 // Deserialize decodes a json payload into a Message.
 func (s *JSONSerializer) Deserialize(data []byte) (wamp.Message, error) {
 	var v []interface{}
-	jsh := &codec.JsonHandle{}
-	jsh.MapType = reflect.TypeOf(map[string]interface{}(nil))
-	err := codec.NewDecoderBytes(data, jsh).Decode(&v)
+	err := codec.NewDecoderBytes(data, jh).Decode(&v)
 	if err != nil {
 		return nil, err
 	}
@@ -55,14 +58,12 @@ type BinaryData []byte
 func (b BinaryData) MarshalJSON() ([]byte, error) {
 	s := base64.StdEncoding.EncodeToString([]byte(b))
 	var out []byte
-	jsh := &codec.JsonHandle{}
-	return out, codec.NewEncoderBytes(&out, jsh).Encode("\x00" + s)
+	return out, codec.NewEncoderBytes(&out, jh).Encode("\x00" + s)
 }
 
 func (b *BinaryData) UnmarshalJSON(v []byte) error {
 	var s string
-	jsh := &codec.JsonHandle{}
-	err := codec.NewDecoderBytes(v, jsh).Decode(&s)
+	err := codec.NewDecoderBytes(v, jh).Decode(&s)
 	if err != nil {
 		return nil
 	}

--- a/transport/serialize/msgpackserializer.go
+++ b/transport/serialize/msgpackserializer.go
@@ -8,17 +8,7 @@ import (
 	"github.com/ugorji/go/codec"
 )
 
-const BinaryDataMsgpackExt byte = 42
-
 var mh *codec.MsgpackHandle
-
-func encodeBinData(value reflect.Value) ([]byte, error) {
-	return value.Bytes(), nil
-}
-func decodeBinData(value reflect.Value, data []byte) error {
-	value.Elem().SetBytes(data)
-	return nil
-}
 
 func init() {
 	mh = &codec.MsgpackHandle{
@@ -26,12 +16,11 @@ func init() {
 		WriteExt:    true,
 	}
 	mh.MapType = reflect.TypeOf(map[string]interface{}(nil))
-	mh.AddExt(
-		reflect.TypeOf(BinaryData{}),
-		BinaryDataMsgpackExt,
-		encodeBinData,
-		decodeBinData,
-	)
+}
+
+// MsgpackRegisterExtension registers a custom type for special serialization.
+func MsgpackRegisterExtension(t reflect.Type, ext byte, encode func(reflect.Value) ([]byte, error), decode func(reflect.Value, []byte) error) {
+	mh.AddExt(t, ext, encode, decode)
 }
 
 // MessagePackSerializer is an implementation of Serializer that handles

--- a/transport/serialize/msgpackserializer.go
+++ b/transport/serialize/msgpackserializer.go
@@ -8,6 +8,15 @@ import (
 	"github.com/ugorji/go/codec"
 )
 
+func init() {
+	mh = &codec.MsgpackHandle{
+		RawToString: true,
+	}
+	mh.MapType = reflect.TypeOf(map[string]interface{}(nil))
+}
+
+var mh *codec.MsgpackHandle
+
 // MessagePackSerializer is an implementation of Serializer that handles
 // serializing and deserializing msgpack encoded payloads.
 type MessagePackSerializer struct{}
@@ -15,22 +24,14 @@ type MessagePackSerializer struct{}
 // Serialize encodes a Message into a msgpack payload.
 func (s *MessagePackSerializer) Serialize(msg wamp.Message) ([]byte, error) {
 	var b []byte
-	mph := &codec.MsgpackHandle{
-		RawToString: true,
-	}
-	mph.MapType = reflect.TypeOf(map[string]interface{}(nil))
-	return b, codec.NewEncoderBytes(&b, mph).Encode(
+	return b, codec.NewEncoderBytes(&b, mh).Encode(
 		msgToList(msg))
 }
 
 // Deserialize decodes a msgpack payload into a Message.
 func (s *MessagePackSerializer) Deserialize(data []byte) (wamp.Message, error) {
 	var v []interface{}
-	mph := &codec.MsgpackHandle{
-		RawToString: true,
-	}
-	mph.MapType = reflect.TypeOf(map[string]interface{}(nil))
-	err := codec.NewDecoderBytes(data, mph).Decode(&v)
+	err := codec.NewDecoderBytes(data, mh).Decode(&v)
 	if err != nil {
 		return nil, err
 	}

--- a/transport/serialize/msgpackserializer.go
+++ b/transport/serialize/msgpackserializer.go
@@ -8,14 +8,31 @@ import (
 	"github.com/ugorji/go/codec"
 )
 
+const BinaryDataMsgpackExt byte = 42
+
+var mh *codec.MsgpackHandle
+
+func encodeBinData(value reflect.Value) ([]byte, error) {
+	return value.Bytes(), nil
+}
+func decodeBinData(value reflect.Value, data []byte) error {
+	value.Elem().SetBytes(data)
+	return nil
+}
+
 func init() {
 	mh = &codec.MsgpackHandle{
 		RawToString: true,
+		WriteExt:    true,
 	}
 	mh.MapType = reflect.TypeOf(map[string]interface{}(nil))
+	mh.AddExt(
+		reflect.TypeOf(BinaryData{}),
+		BinaryDataMsgpackExt,
+		encodeBinData,
+		decodeBinData,
+	)
 }
-
-var mh *codec.MsgpackHandle
 
 // MessagePackSerializer is an implementation of Serializer that handles
 // serializing and deserializing msgpack encoded payloads.

--- a/transport/serialize/serializer_test.go
+++ b/transport/serialize/serializer_test.go
@@ -177,7 +177,7 @@ func TestMessagePackDeserialize(t *testing.T) {
 	}
 }
 
-func TestBinaryData(t *testing.T) {
+func TestBinaryDataJSON(t *testing.T) {
 	orig := []byte("hellowamp")
 
 	// Calls the customer encoder: BinaryData.MarshalJSON()
@@ -200,6 +200,35 @@ func TestBinaryData(t *testing.T) {
 	}
 	if !bytes.Equal([]byte(b), orig) {
 		t.Fatalf("got %s, expected %s", string(b), string(orig))
+	}
+}
+
+func TestBinaryDataMsgpack(t *testing.T) {
+	orig := []byte("hellowamp")
+	msg := &wamp.Welcome{
+		ID: wamp.ID(123),
+		Details: wamp.Dict{
+			"extra": BinaryData(orig),
+		},
+	}
+	ser := MessagePackSerializer{}
+	// Calls the customer encoder: BinaryData.MarshalJSON()
+	bin, err := ser.Serialize(msg)
+	if err != nil {
+		t.Fatal("Error marshalling msg: ", err)
+	}
+	fmt.Printf("%v\n", bin)
+	expect := []byte{147, 2, 123, 129, 165, 101, 120, 116, 114, 97, 199, 9, 42, 104, 101, 108, 108, 111, 119, 97, 109, 112}
+	if !bytes.Equal(expect, bin) {
+		t.Fatalf("got %v, expected %v", bin, expect)
+	}
+
+	c, err := ser.Deserialize(bin)
+	if err != nil {
+		t.Fatal("Error deserializing msg: ", err)
+	}
+	if !reflect.DeepEqual(msg, c) {
+		t.Fatalf("Values are not equal: expected: %v, got: %v", msg, c)
 	}
 }
 
@@ -334,8 +363,8 @@ func TestMsgPackToJSON(t *testing.T) {
 		t.Fatal("JSON desrialization to wrong message type: ", msg.MessageType())
 	}
 	e2 := msg.(*wamp.Event)
-	fmt.Printf("Before:\n%+v\n", event)
-	fmt.Printf("After:\n%+v\n", e2)
+	//fmt.Printf("Before:\n%+v\n", event)
+	//fmt.Printf("After:\n%+v\n", e2)
 	if e2.Subscription != wamp.ID(987) {
 		t.Fatal("JSON deserialization error: wrong subscription ID")
 	}


### PR DESCRIPTION
This PR simplifies the usage of handles of the codec library, since they are safe for concurrent reads by multiple encoders/decoders. This reduces overhead and memory consumption.

Furthermore I implemented a custom serialization for the BinaryData type which is not yet covered by the spec, but is required to recognize the intention of the user (send data as binary) in the client AND in the router. 
Therefore it is now possible to have reencoded messages in the router to keep the binary type.