### PR TITLE
New session meta procedures for session kill

### DIFF
--- a/aat/main_test.go
+++ b/aat/main_test.go
@@ -115,6 +115,9 @@ func TestMain(m *testing.M) {
 				StrictURI:     false,
 				AnonymousAuth: true,
 				AllowDisclose: false,
+
+				EnableMetaKill:   true,
+				EnableMetaModify: true,
 			},
 			{
 				URI:               wamp.URI(testAuthRealm),

--- a/aat/main_test.go
+++ b/aat/main_test.go
@@ -128,6 +128,9 @@ func TestMain(m *testing.M) {
 
 				MetaStrict:                true,
 				MetaIncludeSessionDetails: []string{"foobar"},
+
+				EnableMetaKill:   true,
+				EnableMetaModify: true,
 			},
 		},
 		//Debug: true,

--- a/aat/session_meta_kill_test.go
+++ b/aat/session_meta_kill_test.go
@@ -37,11 +37,12 @@ func TestSessionKill(t *testing.T) {
 		t.Fatal("Failed to connect client:", err)
 	}
 
-	reason := wamp.URI("foo.bar.baz")
+	reason := wamp.URI("test.session.kill")
 	message := "this is a test"
 
 	// Call meta procedure to kill a client-3
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
 	args := wamp.List{cli3.ID()}
 	kwArgs := wamp.Dict{"reason": reason, "message": message}
 	result, err := cli1.Call(ctx, metaKill, nil, args, kwArgs, "")
@@ -57,6 +58,21 @@ func TestSessionKill(t *testing.T) {
 	case <-cli3.Done():
 	case <-time.After(time.Second):
 		t.Fatal("Client 3 did not shutdown")
+	}
+	// Check for expected GOODBYE message.
+	goodbye := cli3.RouterGoodbye()
+	if goodbye == nil {
+		t.Error("Did not receive goodbye from router")
+	}
+	if goodbye.Reason != reason {
+		t.Error("Did not get expected GOODBYE.Reason, got:", goodbye.Reason)
+	}
+	if gm, ok := wamp.AsString(goodbye.Details["message"]); ok {
+		if gm != message {
+			t.Error("Did not get expected goodbye message, got:", gm)
+		}
+	} else {
+		t.Error("Expected message in GOODBYE")
 	}
 
 	// Check that client-2 is still connected.
@@ -80,6 +96,18 @@ func TestSessionKill(t *testing.T) {
 		t.Error("Wrong error, got", rpcErr.Err.Error, "expected", wamp.ErrNoSuchSession)
 	}
 
+	// Test that killing a sesson that does not exist works correctly.
+	ctx, c2 := context.WithTimeout(context.Background(), time.Second)
+	defer c2()
+	args = wamp.List{wamp.ID(12345)}
+	kwArgs = wamp.Dict{"reason": reason, "message": message}
+	result, err = cli1.Call(ctx, metaKill, nil, args, kwArgs, "")
+	if err == nil {
+		t.Error("Expected error")
+	} else if _, ok := err.(client.RPCError); !ok {
+		t.Fatal("Expected RPCError")
+	}
+
 	// Make sure everything closes correctly.
 	if err = cli3.Close(); err != nil {
 		t.Error(err)
@@ -89,5 +117,159 @@ func TestSessionKill(t *testing.T) {
 	}
 	if err = cli1.Close(); err != nil {
 		t.Error(err)
+	}
+}
+
+func TestSessionKillAll(t *testing.T) {
+	defer leaktest.Check(t)()
+
+	cli1, err := connectClient()
+	if err != nil {
+		t.Fatal("Failed to connect client:", err)
+	}
+	defer cli1.Close()
+
+	cli2, err := connectClient()
+	if err != nil {
+		t.Fatal("Failed to connect client:", err)
+	}
+	defer cli2.Close()
+
+	cli3, err := connectClient()
+	if err != nil {
+		t.Fatal("Failed to connect client:", err)
+	}
+	defer cli3.Close()
+
+	reason := wamp.URI("test.session.kill")
+	message := "this is a test"
+
+	// Call meta procedure to kill a client-3
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	kwArgs := wamp.Dict{"reason": reason, "message": message}
+	result, err := cli1.Call(ctx, metaKillAll, nil, nil, kwArgs, "")
+	if err != nil {
+		t.Fatal("Call error:", err)
+	}
+	if result == nil {
+		t.Error("Did not receive result")
+	}
+
+	// Check that client-3 was booted.
+	select {
+	case <-cli3.Done():
+	case <-time.After(time.Second):
+		t.Fatal("Client 3 did not shutdown")
+	}
+	// Check for expected GOODBYE message.
+	goodbye := cli3.RouterGoodbye()
+	if goodbye == nil {
+		t.Error("Did not receive goodbye from router")
+	}
+	if goodbye.Reason != reason {
+		t.Error("Did not get expected GOODBYE.Reason, got:", goodbye.Reason)
+	}
+	gm, ok := wamp.AsString(goodbye.Details["message"])
+	if !ok {
+		t.Error("Expected message in GOODBYE")
+	} else if gm != message {
+		t.Error("Did not get expected goodbye message, got:", gm)
+	}
+
+	// Check that client-2 was booted.
+	select {
+	case <-cli2.Done():
+	case <-time.After(time.Second):
+		t.Fatal("Client 2 did not shutdown")
+	}
+
+	// Test that client-1 still connected.
+	select {
+	case <-cli1.Done():
+		t.Fatal("Client 1 should still be connected")
+	default:
+	}
+
+	cli4, err := connectClient()
+	if err != nil {
+		t.Fatal("Failed to connect client:", err)
+	}
+	defer cli4.Close()
+
+	// Call killall again, with no reason.
+	ctx, c2 := context.WithTimeout(context.Background(), time.Second)
+	defer c2()
+	result, err = cli1.Call(ctx, metaKillAll, nil, nil, nil, "")
+	if err != nil {
+		t.Fatal("Call error:", err)
+	}
+	if result == nil {
+		t.Error("Did not receive result")
+	}
+
+	// Check that client-4 was booted.
+	select {
+	case <-cli4.Done():
+	case <-time.After(time.Second):
+		t.Fatal("Client 4 did not shutdown")
+	}
+
+	// Check for expected GOODBYE message.
+	goodbye = cli4.RouterGoodbye()
+	if goodbye == nil {
+		t.Error("Did not receive goodbye from router")
+	}
+	if goodbye.Reason != wamp.CloseNormal {
+		t.Error("Did not get expected GOODBYE.Reason, got:", goodbye.Reason)
+	}
+	if _, ok = goodbye.Details["message"]; ok {
+		t.Error("Should not have received message in GOODBYE.Details")
+	}
+}
+
+func TestSessionModifyDetails(t *testing.T) {
+	defer leaktest.Check(t)()
+
+	cli, err := connectClient()
+	if err != nil {
+		t.Fatal("Failed to connect client:", err)
+	}
+	defer cli.Close()
+
+	// Call meta procedure to modify details.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	delta := wamp.Dict{"pi": 3.14, "authid": "bob"}
+	args := wamp.List{cli.ID(), delta}
+	result, err := cli.Call(ctx, metaModifyDetails, nil, args, nil, "")
+	if err != nil {
+		t.Fatal("Call error:", err)
+	}
+	if result == nil {
+		t.Error("Did not receive result")
+	}
+
+	// Call session meta-procedure to get session information.
+	ctx = context.Background()
+	args = wamp.List{cli.ID()}
+	result, err = cli.Call(ctx, metaGet, nil, args, nil, "")
+	if err != nil {
+		t.Fatal("Call error:", err)
+	}
+	if len(result.Arguments) == 0 {
+		t.Fatal("Missing result argument")
+	}
+	details, ok := wamp.AsDict(result.Arguments[0])
+	if !ok {
+		t.Fatal("Could not convert result to wamp.Dict")
+	}
+	pi, _ := wamp.AsFloat64(details["pi"])
+	if pi != 3.14 {
+		t.Fatal("Wrong value for detail pi, got", details["pi"])
+	}
+	authid, _ := wamp.AsString(details["authid"])
+	if authid != "bob" {
+		t.Fatal("Wrong value for detail authid")
 	}
 }

--- a/aat/session_meta_kill_test.go
+++ b/aat/session_meta_kill_test.go
@@ -1,0 +1,93 @@
+package aat
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/fortytw2/leaktest"
+	"github.com/gammazero/nexus/client"
+	"github.com/gammazero/nexus/wamp"
+)
+
+const (
+	metaKill           = string(wamp.MetaProcSessionKill)
+	metaKillByAuthid   = string(wamp.MetaProcSessionKillByAuthid)
+	metaKillByAuthrole = string(wamp.MetaProcSessionKillByAuthrole)
+	metaKillAll        = string(wamp.MetaProcSessionKillAll)
+
+	metaModifyDetails = string(wamp.MetaProcSessionModifyDetails)
+)
+
+func TestSessionKill(t *testing.T) {
+	defer leaktest.Check(t)()
+
+	cli1, err := connectClient()
+	if err != nil {
+		t.Fatal("Failed to connect client:", err)
+	}
+
+	cli2, err := connectClient()
+	if err != nil {
+		t.Fatal("Failed to connect client:", err)
+	}
+
+	cli3, err := connectClient()
+	if err != nil {
+		t.Fatal("Failed to connect client:", err)
+	}
+
+	reason := wamp.URI("foo.bar.baz")
+	message := "this is a test"
+
+	// Call meta procedure to kill a client-3
+	ctx := context.Background()
+	args := wamp.List{cli3.ID()}
+	kwArgs := wamp.Dict{"reason": reason, "message": message}
+	result, err := cli1.Call(ctx, metaKill, nil, args, kwArgs, "")
+	if err != nil {
+		t.Fatal("Call error:", err)
+	}
+	if result == nil {
+		t.Error("Did not receive result")
+	}
+
+	// Check that client-3 was booted.
+	select {
+	case <-cli3.Done():
+	case <-time.After(time.Second):
+		t.Fatal("Client 3 did not shutdown")
+	}
+
+	// Check that client-2 is still connected.
+	select {
+	case <-cli2.Done():
+		t.Fatal("Client 2 should still be connected")
+	default:
+	}
+
+	// Test that trying to kill self receives error.
+	args = wamp.List{cli1.ID}
+	result, err = cli1.Call(ctx, metaKill, nil, args, kwArgs, "")
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+	rpcErr, ok := err.(client.RPCError)
+	if !ok {
+		t.Fatal("Expected RPCError")
+	}
+	if rpcErr.Err.Error != wamp.ErrNoSuchSession {
+		t.Error("Wrong error, got", rpcErr.Err.Error, "expected", wamp.ErrNoSuchSession)
+	}
+
+	// Make sure everything closes correctly.
+	if err = cli3.Close(); err != nil {
+		t.Error(err)
+	}
+	if err = cli2.Close(); err != nil {
+		t.Error(err)
+	}
+	if err = cli1.Close(); err != nil {
+		t.Error(err)
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -815,7 +815,7 @@ func (c *Client) leaveRealm() {
 	// which is handled by receiveFromRouter, and causes run() to exit.
 	c.sess.Send(&wamp.Goodbye{
 		Details: wamp.Dict{},
-		Reason:  wamp.ErrCloseRealm,
+		Reason:  wamp.CloseRealm,
 	})
 
 	// Close the peer.  This causes run() to exit if it has not already done so

--- a/client/client.go
+++ b/client/client.go
@@ -811,9 +811,17 @@ func joinRealm(peer wamp.Peer, cfg Config) (*wamp.Welcome, error) {
 // leaveRealm leaves the current realm without closing the connection to the
 // router.
 func (c *Client) leaveRealm() {
+	select {
+	case <-c.done: // run already exited, client already disconnected
+		return
+	default:
+	}
+
 	// Send GOODBYE to router.  The router will respond with a GOODBYE message
 	// which is handled by receiveFromRouter, and causes run() to exit.
-	c.sess.Send(&wamp.Goodbye{
+	//
+	// Make an effort to say goodbye, but do not wait around if blocked.
+	c.sess.TrySend(&wamp.Goodbye{
 		Details: wamp.Dict{},
 		Reason:  wamp.CloseRealm,
 	})

--- a/router/authorizer_test.go
+++ b/router/authorizer_test.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gammazero/nexus/wamp"
 )
@@ -14,13 +15,25 @@ const (
 // testAuthz implements Authorizer interface.
 type testAuthz struct{}
 
-func (a *testAuthz) Authorize(sess *wamp.Session, msg wamp.Message) (bool, error) {
+func (a *testAuthz) Authorize(session *wamp.Session, msg wamp.Message) (bool, error) {
 	m, ok := msg.(*wamp.Subscribe)
 	if ok {
 		if m.Topic == denyTopic {
 			return false, nil
 		}
 	}
+	return true, nil
+}
+
+type testAuthzMod struct{}
+
+// Authorize implementation that modifies the session details.
+func (a *testAuthzMod) Authorize(sess *wamp.Session, msg wamp.Message) (bool, error) {
+	count, _ := wamp.AsInt64(sess.Details["count"])
+	count++
+	sess.Details["count"] = count
+	sess.Details["foo"] = "bar"
+	delete(sess.Details, "xyzzy")
 	return true, nil
 }
 
@@ -48,7 +61,7 @@ func TestAuthorizer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Test that authroizer forbids denyTopic.
+	// Test that authorizer forbids denyTopic.
 	subscribeID := wamp.GlobalID()
 	sub.Send(&wamp.Subscribe{Request: subscribeID, Topic: denyTopic})
 	msg := <-sub.Recv()
@@ -57,7 +70,7 @@ func TestAuthorizer(t *testing.T) {
 		t.Fatal("Expected ERROR, got:", msg.MessageType())
 	}
 
-	// Test that authroizer allows allowTopic.
+	// Test that authorizer allows allowTopic.
 	sub.Send(&wamp.Subscribe{Request: subscribeID, Topic: allowTopic})
 	msg = <-sub.Recv()
 	if _, ok = msg.(*wamp.Subscribed); !ok {
@@ -65,14 +78,14 @@ func TestAuthorizer(t *testing.T) {
 	}
 }
 
-// Test that authroizer is not called with a local session and config does not
+// Test that authorizer is not called with a local session and config does not
 // specify RequireLocalAuthz=true.
 func TestAuthorizerBypassLocal(t *testing.T) {
 	config := &Config{
 		RealmConfigs: []*RealmConfig{
 			{
 				URI:        testRealm,
-				Authorizer: &testAuthz{},
+				Authorizer: &testAuthzMod{},
 			},
 		},
 		Debug: debug,
@@ -94,4 +107,146 @@ func TestAuthorizerBypassLocal(t *testing.T) {
 	if _, ok := msg.(*wamp.Subscribed); !ok {
 		t.Fatal("Expected SUBSCRIBED, got:", msg.MessageType())
 	}
+}
+
+func TestAuthorizerModify(t *testing.T) {
+	config := &Config{
+		RealmConfigs: []*RealmConfig{
+			{
+				URI:               testRealm,
+				Authorizer:        &testAuthzMod{},
+				RequireLocalAuthz: true,
+			},
+		},
+		Debug: debug,
+	}
+	r, err := NewRouter(config, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	cli, err := testClient(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i <= 10; i++ {
+		cli.Send(&wamp.Call{
+			Request:   wamp.ID(i),
+			Procedure: wamp.MetaProcSessionGet,
+			Arguments: wamp.List{cli.ID},
+		})
+		msg, err := wamp.RecvTimeout(cli, time.Second)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, ok := msg.(*wamp.Result)
+		if !ok {
+			t.Fatal("expected wamp.Result, got", msg.MessageType())
+		}
+		details, ok := wamp.AsDict(result.Arguments[0])
+		if !ok {
+			t.Fatal("Result.Arguments[0] was not wamp.Dict")
+		}
+		i64, ok := wamp.AsInt64(details["count"])
+		if !ok {
+			t.Fatal("Session details did not have count")
+		}
+		if i64 != int64(i) {
+			t.Fatal("Expected count to be", i, "got", i64)
+		}
+		foo, _ := wamp.AsString(details["foo"])
+		if foo != "bar" {
+			t.Fatal("Wrong value for foo")
+		}
+		if _, ok = details["xyzzy"]; ok {
+			t.Fatal("Should not have xyzzy detail")
+		}
+	}
+}
+
+// Test for races when Authorizer modifies session details.
+func TestAuthorizerRace(t *testing.T) {
+	config := &Config{
+		RealmConfigs: []*RealmConfig{
+			{
+				URI:               testRealm,
+				Authorizer:        &testAuthzMod{},
+				RequireLocalAuthz: true,
+			},
+		},
+		Debug: debug,
+	}
+	r, err := NewRouter(config, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	sub, err := testClient(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pub, err := testClient(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cli, err := testClient(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test that authorizer forbids denyTopic.
+	subscribeID := wamp.GlobalID()
+	const topic = "whatever.topic"
+	sub.Send(&wamp.Subscribe{Request: subscribeID, Topic: topic})
+	msg, err := wamp.RecvTimeout(sub, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := msg.(*wamp.Subscribed); !ok {
+		t.Fatal("Expected SUBSCRIBED, got:", msg.MessageType())
+	}
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 100; i++ {
+			pub.Send(&wamp.Publish{
+				Request: wamp.ID(i),
+				Topic:   topic,
+				Options: wamp.Dict{"eligible_xyzzy": wamp.List{"plugh", "baz"}},
+			})
+		}
+		done <- struct{}{}
+	}()
+
+	go func() {
+		for i := 0; i < 100; i++ {
+			cli.Send(&wamp.Call{
+				Request:   wamp.ID(100 + i),
+				Procedure: wamp.MetaProcSessionGet,
+				Arguments: wamp.List{pub.ID},
+			})
+			<-cli.Recv()
+			cli.Send(&wamp.Call{
+				Request:   wamp.ID(200 + i),
+				Procedure: wamp.MetaProcSessionGet,
+				Arguments: wamp.List{sub.ID},
+			})
+			<-cli.Recv()
+		}
+		done <- struct{}{}
+	}()
+
+	for i := 0; i < 100; i++ {
+		sub.Send(&wamp.Publish{
+			Request: wamp.ID(500 + i),
+			Topic:   topic,
+			Options: wamp.Dict{"eligible_xyzzy": wamp.List{"plugh"}},
+		})
+	}
+	<-done
+	<-done
 }

--- a/router/dealer_test.go
+++ b/router/dealer_test.go
@@ -45,7 +45,7 @@ func TestBasicRegister(t *testing.T) {
 
 	// Register callee
 	callee := newTestPeer()
-	sess := &wamp.Session{Peer: callee}
+	sess := newSession(callee, 0, nil)
 	dealer.Register(sess, &wamp.Register{Request: 123, Procedure: testProcedure})
 
 	rsp := <-callee.Recv()
@@ -100,7 +100,7 @@ func TestUnregister(t *testing.T) {
 
 	// Register a procedure.
 	callee := newTestPeer()
-	sess := &wamp.Session{Peer: callee}
+	sess := newSession(callee, 0, nil)
 	dealer.Register(sess, &wamp.Register{Request: 123, Procedure: testProcedure})
 	rsp := <-callee.Recv()
 	regID := rsp.(*wamp.Registered).Registration
@@ -150,7 +150,7 @@ func TestBasicCall(t *testing.T) {
 
 	// Register a procedure.
 	callee := newTestPeer()
-	calleeSess := &wamp.Session{Peer: callee}
+	calleeSess := newSession(callee, 0, nil)
 	dealer.Register(calleeSess,
 		&wamp.Register{Request: 123, Procedure: testProcedure})
 	rsp := <-callee.Recv()
@@ -166,7 +166,7 @@ func TestBasicCall(t *testing.T) {
 	}
 
 	caller := newTestPeer()
-	callerSession := &wamp.Session{Peer: caller}
+	callerSession := newSession(caller, 0, nil)
 
 	// Test calling invalid procedure
 	dealer.Call(callerSession,
@@ -235,7 +235,7 @@ func TestRemovePeer(t *testing.T) {
 
 	// Register a procedure.
 	callee := newTestPeer()
-	sess := &wamp.Session{Peer: callee}
+	sess := newSession(callee, 0, nil)
 	msg := &wamp.Register{Request: 123, Procedure: testProcedure}
 	dealer.Register(sess, msg)
 	rsp := <-callee.Recv()
@@ -259,7 +259,7 @@ func TestRemovePeer(t *testing.T) {
 	dealer.RemoveSession(sess)
 
 	// Register as a way to sync with dealer.
-	sess2 := &wamp.Session{Peer: callee}
+	sess2 := newSession(callee, 0, nil)
 	dealer.Register(sess2,
 		&wamp.Register{Request: 789, Procedure: wamp.URI("nexus.test.p2")})
 	rsp = <-callee.Recv()
@@ -297,7 +297,7 @@ func TestCancelCallModeKill(t *testing.T) {
 
 	// Register a procedure.
 	callee := newTestPeer()
-	calleeSess := &wamp.Session{Peer: callee, Details: calleeRoles}
+	calleeSess := newSession(callee, 0, calleeRoles)
 	dealer.Register(calleeSess,
 		&wamp.Register{Request: 123, Procedure: testProcedure})
 	rsp := <-callee.Recv()
@@ -311,7 +311,7 @@ func TestCancelCallModeKill(t *testing.T) {
 	}
 
 	caller := newTestPeer()
-	callerSession := &wamp.Session{Peer: caller}
+	callerSession := newSession(caller, 0, nil)
 
 	// Test calling valid procedure
 	dealer.Call(callerSession,
@@ -378,7 +378,7 @@ func TestCancelCallModeKillNoWait(t *testing.T) {
 
 	// Register a procedure.
 	callee := newTestPeer()
-	calleeSess := &wamp.Session{Peer: callee, Details: calleeRoles}
+	calleeSess := newSession(callee, 0, calleeRoles)
 	dealer.Register(calleeSess,
 		&wamp.Register{Request: 123, Procedure: testProcedure})
 	rsp := <-callee.Recv()
@@ -392,7 +392,7 @@ func TestCancelCallModeKillNoWait(t *testing.T) {
 	}
 
 	caller := newTestPeer()
-	callerSession := &wamp.Session{Peer: caller}
+	callerSession := newSession(caller, 0, nil)
 
 	// Test calling valid procedure
 	dealer.Call(callerSession,
@@ -456,7 +456,7 @@ func TestCancelCallModeSkip(t *testing.T) {
 		},
 	}
 
-	calleeSess := &wamp.Session{Peer: callee, Details: calleeRoles}
+	calleeSess := newSession(callee, 0, calleeRoles)
 	dealer.Register(calleeSess,
 		&wamp.Register{Request: 123, Procedure: testProcedure})
 	rsp := <-callee.Recv()
@@ -470,7 +470,7 @@ func TestCancelCallModeSkip(t *testing.T) {
 	}
 
 	caller := newTestPeer()
-	callerSession := &wamp.Session{Peer: caller}
+	callerSession := newSession(caller, 0, nil)
 
 	// Test calling valid procedure
 	dealer.Call(callerSession,
@@ -520,7 +520,7 @@ func TestSharedRegistrationRoundRobin(t *testing.T) {
 
 	// Register callee1 with roundrobin shared registration
 	callee1 := newTestPeer()
-	calleeSess1 := &wamp.Session{Peer: callee1, Details: calleeRoles}
+	calleeSess1 := newSession(callee1, 0, calleeRoles)
 	dealer.Register(calleeSess1, &wamp.Register{
 		Request:   123,
 		Procedure: testProcedure,
@@ -542,7 +542,7 @@ func TestSharedRegistrationRoundRobin(t *testing.T) {
 
 	// Register callee2 with roundrobin shared registration
 	callee2 := newTestPeer()
-	calleeSess2 := &wamp.Session{Peer: callee2, Details: calleeRoles}
+	calleeSess2 := newSession(callee2, 0, calleeRoles)
 	dealer.Register(calleeSess2, &wamp.Register{
 		Request:   124,
 		Procedure: testProcedure,
@@ -564,7 +564,7 @@ func TestSharedRegistrationRoundRobin(t *testing.T) {
 
 	// Test calling valid procedure
 	caller := newTestPeer()
-	callerSession := &wamp.Session{Peer: caller}
+	callerSession := newSession(caller, 0, nil)
 	dealer.Call(callerSession,
 		&wamp.Call{Request: 125, Procedure: testProcedure})
 
@@ -639,7 +639,7 @@ func TestSharedRegistrationFirst(t *testing.T) {
 
 	// Register callee1 with first shared registration
 	callee1 := newTestPeer()
-	calleeSess1 := &wamp.Session{Peer: callee1, Details: calleeRoles}
+	calleeSess1 := newSession(callee1, 0, calleeRoles)
 	dealer.Register(calleeSess1, &wamp.Register{
 		Request:   123,
 		Procedure: testProcedure,
@@ -661,7 +661,7 @@ func TestSharedRegistrationFirst(t *testing.T) {
 
 	// Register callee2 with roundrobin shared registration
 	callee2 := newTestPeer()
-	calleeSess2 := &wamp.Session{Peer: callee2, Details: calleeRoles}
+	calleeSess2 := newSession(callee2, 0, calleeRoles)
 	dealer.Register(calleeSess2, &wamp.Register{
 		Request:   1233,
 		Procedure: testProcedure,
@@ -694,7 +694,7 @@ func TestSharedRegistrationFirst(t *testing.T) {
 
 	// Test calling valid procedure
 	caller := newTestPeer()
-	callerSession := &wamp.Session{Peer: caller}
+	callerSession := newSession(caller, 0, nil)
 	dealer.Call(callerSession,
 		&wamp.Call{Request: 125, Procedure: testProcedure})
 
@@ -807,7 +807,7 @@ func TestSharedRegistrationLast(t *testing.T) {
 
 	// Register callee1 with last shared registration
 	callee1 := newTestPeer()
-	calleeSess1 := &wamp.Session{Peer: callee1, Details: calleeRoles}
+	calleeSess1 := newSession(callee1, 0, calleeRoles)
 	dealer.Register(calleeSess1, &wamp.Register{
 		Request:   123,
 		Procedure: testProcedure,
@@ -828,7 +828,7 @@ func TestSharedRegistrationLast(t *testing.T) {
 
 	// Register callee2 with last shared registration
 	callee2 := newTestPeer()
-	calleeSess2 := &wamp.Session{Peer: callee2, Details: calleeRoles}
+	calleeSess2 := newSession(callee2, 0, calleeRoles)
 	dealer.Register(calleeSess2, &wamp.Register{
 		Request:   124,
 		Procedure: testProcedure,
@@ -844,7 +844,7 @@ func TestSharedRegistrationLast(t *testing.T) {
 
 	// Test calling valid procedure
 	caller := newTestPeer()
-	callerSession := &wamp.Session{Peer: caller}
+	callerSession := newSession(caller, 0, nil)
 	dealer.Call(callerSession,
 		&wamp.Call{Request: 125, Procedure: testProcedure})
 
@@ -957,7 +957,7 @@ func TestPatternBasedRegistration(t *testing.T) {
 
 	// Register a procedure with wildcard match.
 	callee := newTestPeer()
-	calleeSess := &wamp.Session{Peer: callee, Details: calleeRoles}
+	calleeSess := newSession(callee, 0, calleeRoles)
 	dealer.Register(calleeSess,
 		&wamp.Register{
 			Request:   123,
@@ -977,7 +977,7 @@ func TestPatternBasedRegistration(t *testing.T) {
 	}
 
 	caller := newTestPeer()
-	callerSession := &wamp.Session{Peer: caller}
+	callerSession := newSession(caller, 0, nil)
 
 	// Test calling valid procedure with full name.  Widlcard should match.
 	dealer.Call(callerSession,
@@ -1008,7 +1008,7 @@ func TestRPCBlockedSlowClientCall(t *testing.T) {
 
 	// Register a procedure.
 	callee, rtr := transport.LinkedPeers()
-	calleeSess := &wamp.Session{Peer: rtr}
+	calleeSess := newSession(rtr, 0, nil)
 	dealer.Register(calleeSess,
 		&wamp.Register{Request: 223, Procedure: testProcedure})
 	rsp := <-callee.Recv()
@@ -1022,7 +1022,7 @@ func TestRPCBlockedSlowClientCall(t *testing.T) {
 	}
 
 	caller, rtr := transport.LinkedPeers()
-	callerSession := &wamp.Session{Peer: rtr}
+	callerSession := newSession(rtr, 0, nil)
 
 	for i := 0; i < 20; i++ {
 		fmt.Println("Calling", i)
@@ -1060,7 +1060,7 @@ func TestCallerIdentification(t *testing.T) {
 
 	// Register a procedure, set option to request disclosing caller.
 	callee := newTestPeer()
-	calleeSess := &wamp.Session{Peer: callee, Details: calleeRoles}
+	calleeSess := newSession(callee, 0, calleeRoles)
 	dealer.Register(calleeSess,
 		&wamp.Register{
 			Request:   123,
@@ -1081,7 +1081,7 @@ func TestCallerIdentification(t *testing.T) {
 
 	caller := newTestPeer()
 	callerID := wamp.ID(11235813)
-	callerSession := &wamp.Session{Peer: caller, ID: callerID}
+	callerSession := newSession(caller, callerID, nil)
 
 	// Test calling valid procedure with full name.  Widlcard should match.
 	dealer.Call(callerSession,

--- a/router/publishfilter_test.go
+++ b/router/publishfilter_test.go
@@ -37,27 +37,18 @@ func TestFilterBlacklist(t *testing.T) {
 		"authrole": allowedAuthrole,
 		"misc":     "other",
 	}
-	sess := &wamp.Session{
-		ID:      allowedID,
-		Details: details,
-	}
+	sess := newSession(nil, allowedID, details)
 	if !pf.publishAllowed(sess) {
 		t.Error(shouldAllowMsg)
 	}
 
-	sess = &wamp.Session{
-		ID:      blacklistID,
-		Details: details,
-	}
+	sess = newSession(nil, blacklistID, details)
 	// Check that session is denied by ID.
 	if pf.publishAllowed(sess) {
 		t.Error(shouldDenyMsg)
 	}
 
-	sess = &wamp.Session{
-		ID:      allowedID,
-		Details: details,
-	}
+	sess = newSession(nil, allowedID, details)
 	// Check that session is denied by authid.
 	sess.Details["authid"] = blacklistAuthid
 	if pf.publishAllowed(sess) {
@@ -109,27 +100,18 @@ func TestFilterWhitelist(t *testing.T) {
 		"authrole": allowedAuthrole,
 		"misc":     "other",
 	}
-	sess := &wamp.Session{
-		ID:      allowedID,
-		Details: details,
-	}
+	sess := newSession(nil, allowedID, details)
 	if !pf.publishAllowed(sess) {
 		t.Error(shouldAllowMsg)
 	}
 
-	sess = &wamp.Session{
-		ID:      deniedID,
-		Details: details,
-	}
+	sess = newSession(nil, deniedID, details)
 	// Check that session is denied by ID.
 	if pf.publishAllowed(sess) {
 		t.Error(shouldDenyMsg)
 	}
 
-	sess = &wamp.Session{
-		ID:      allowedID,
-		Details: details,
-	}
+	sess = newSession(nil, allowedID, details)
 	// Check that session is denied by authid.
 	sess.Details["authid"] = deniedAuthid
 	if pf.publishAllowed(sess) {
@@ -185,27 +167,18 @@ func TestFilterBlackWhitelistPrecedence(t *testing.T) {
 		"misc":     "other",
 	}
 
-	sess := &wamp.Session{
-		ID:      allowedID,
-		Details: details,
-	}
+	sess := newSession(nil, allowedID, details)
 	if !pf.publishAllowed(sess) {
 		t.Error(shouldAllowMsg)
 	}
 
-	sess = &wamp.Session{
-		ID:      blacklistID,
-		Details: details,
-	}
+	sess = newSession(nil, blacklistID, details)
 	// Check that session is denied by ID even thought ID is also in whitelist.
 	if pf.publishAllowed(sess) {
 		t.Error(shouldDenyMsg)
 	}
-	sess = &wamp.Session{
-		ID:      allowedID,
-		Details: details,
-	}
 
+	sess = newSession(nil, allowedID, details)
 	// Check that session is denied by authid even though also whitelisted.
 	sess.Details["authid"] = blacklistAuthid
 	if pf.publishAllowed(sess) {

--- a/router/realm.go
+++ b/router/realm.go
@@ -1252,13 +1252,13 @@ func (r *realm) modifySessionDetails(sess *session, delta wamp.Dict) {
 
 	for k, v := range delta {
 		if v == nil {
-			if r.debug || true {
+			if r.debug {
 				r.log.Println("Deleted", k, "from session details")
 			}
 			delete(sess.Details, k)
 			continue
 		}
-		if r.debug || true {
+		if r.debug {
 			r.log.Println("Updated", k, "in session details")
 		}
 		sess.Details[k] = v

--- a/router/realm.go
+++ b/router/realm.go
@@ -143,6 +143,14 @@ func newRealm(config *RealmConfig, broker *Broker, dealer *Dealer, logger stdlog
 		enableMetaModify: config.EnableMetaModify,
 	}
 
+	if debug {
+		if r.enableMetaKill {
+			r.log.Println("Session meta kill procedures enabled")
+		}
+		if r.enableMetaKill {
+			r.log.Println("Session meta modify_details procedure enabled")
+		}
+	}
 	if r.metaStrict && len(config.MetaIncludeSessionDetails) != 0 {
 		r.metaIncDetails = make([]string, len(config.MetaIncludeSessionDetails))
 		copy(r.metaIncDetails, config.MetaIncludeSessionDetails)

--- a/router/router.go
+++ b/router/router.go
@@ -279,11 +279,7 @@ func (r *router) AttachClient(client wamp.Peer, transportDetails wamp.Dict) erro
 	sessDetails["session"] = sid
 
 	// Create new session.
-	sess := &wamp.Session{
-		Peer:    client,
-		ID:      sid,
-		Details: sessDetails,
-	}
+	sess := newSession(client, sid, sessDetails)
 
 	if err := realm.handleSession(sess); err != nil {
 		// Any error returned here is a shutdown error.

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -1,7 +1,6 @@
 package router
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -72,26 +71,30 @@ func testClientInRealm(r Router, realm wamp.URI) (*wamp.Session, error) {
 	client, server := transport.LinkedPeers()
 	// Run as goroutine since Send will block until message read by router, if
 	// client uses unbuffered channel.
-	go client.Send(&wamp.Hello{Realm: realm, Details: clientRoles})
+	details := clientRoles
+	details["authid"] = "user1"
+	details["xyzzy"] = "plugh"
+	//go client.Send(&wamp.Hello{Realm: realm, Details: clientRoles})
+	go client.Send(&wamp.Hello{Realm: realm, Details: details})
 	err := r.Attach(server)
 	if err != nil {
 		return nil, err
 	}
 
-	var sid wamp.ID
-	select {
-	case <-time.After(time.Second):
-		return nil, errors.New("timed out waiting for welcome")
-	case msg := <-client.Recv():
-		if msg.MessageType() != wamp.WELCOME {
-			return nil, fmt.Errorf("expected %v, got %v", wamp.WELCOME,
-				msg.MessageType())
-		}
-		sid = msg.(*wamp.Welcome).ID
+	msg, err := wamp.RecvTimeout(client, time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("error waiting for welcome: %s", err)
 	}
+	welcome, ok := msg.(*wamp.Welcome)
+	if !ok {
+		return nil, fmt.Errorf("expected %v, got %v", wamp.WELCOME,
+			msg.MessageType())
+	}
+
 	return &wamp.Session{
-		Peer: client,
-		ID:   sid,
+		Peer:    client,
+		ID:      welcome.ID,
+		Details: welcome.Details,
 	}, nil
 }
 
@@ -112,13 +115,12 @@ func TestHandshake(t *testing.T) {
 	}
 
 	cli.Send(&wamp.Goodbye{})
-	select {
-	case <-time.After(time.Second):
-		t.Fatal("no goodbye message after sending goodbye")
-	case msg := <-cli.Recv():
-		if _, ok := msg.(*wamp.Goodbye); !ok {
-			t.Fatal("expected GOODBYE, received:", msg.MessageType())
-		}
+	msg, err := wamp.RecvTimeout(cli, time.Second)
+	if err != nil {
+		t.Fatal("no goodbye message after sending goodbye:", err)
+	}
+	if _, ok := msg.(*wamp.Goodbye); !ok {
+		t.Fatal("expected GOODBYE, received:", msg.MessageType())
 	}
 }
 
@@ -137,13 +139,12 @@ func TestHandshakeBadRealm(t *testing.T) {
 		t.Fatal("expected error")
 	}
 
-	select {
-	case <-time.After(time.Second):
+	msg, err := wamp.RecvTimeout(client, time.Second)
+	if err != nil {
 		t.Fatal("timed out waiting for response to HELLO")
-	case msg := <-client.Recv():
-		if _, ok := msg.(*wamp.Abort); !ok {
-			t.Error("Expected ABORT after bad handshake")
-		}
+	}
+	if _, ok := msg.(*wamp.Abort); !ok {
+		t.Error("Expected ABORT after bad handshake")
 	}
 }
 
@@ -162,19 +163,16 @@ func TestProtocolViolation(t *testing.T) {
 
 	// Send HELLO message after session established.
 	cli.Send(&wamp.Hello{Realm: testRealm, Details: clientRoles})
-	select {
-	case <-time.After(time.Second):
+	msg, err := wamp.RecvTimeout(cli, time.Second)
+	if err != nil {
 		t.Fatal("timed out waiting for ABORT")
-	case msg := <-cli.Recv():
-		abort, ok := msg.(*wamp.Abort)
-		if !ok {
-			t.Fatal("expected ABORT, received:", msg.MessageType())
-		}
-		if abort.Reason != wamp.ErrProtocolViolation {
-			t.Fatal("Expected reason to be", wamp.ErrProtocolViolation)
-		}
-		//errMsg, _ := wamp.AsString(abort.Details["error"])
-		//fmt.Println("===> Abort error:", errMsg)
+	}
+	abort, ok := msg.(*wamp.Abort)
+	if !ok {
+		t.Fatal("expected ABORT, received:", msg.MessageType())
+	}
+	if abort.Reason != wamp.ErrProtocolViolation {
+		t.Fatal("Expected reason to be", wamp.ErrProtocolViolation)
 	}
 
 	// Send SUBSCRIBE before session established.
@@ -186,19 +184,16 @@ func TestProtocolViolation(t *testing.T) {
 		t.Fatal("Expected error from Attach")
 	}
 
-	select {
-	case <-time.After(time.Second):
+	msg, err = wamp.RecvTimeout(client, time.Second)
+	if err != nil {
 		t.Fatal("timed out waiting for ABORT")
-	case msg := <-client.Recv():
-		abort, ok := msg.(*wamp.Abort)
-		if !ok {
-			t.Fatal("expected ABORT, received:", msg.MessageType())
-		}
-		if abort.Reason != wamp.ErrProtocolViolation {
-			t.Fatal("Expected reason to be", wamp.ErrProtocolViolation)
-		}
-		//errMsg, _ := wamp.AsString(abort.Details["error"])
-		//fmt.Println("===> Abort error:", errMsg)
+	}
+	abort, ok = msg.(*wamp.Abort)
+	if !ok {
+		t.Fatal("expected ABORT, received:", msg.MessageType())
+	}
+	if abort.Reason != wamp.ErrProtocolViolation {
+		t.Fatal("Expected reason to be", wamp.ErrProtocolViolation)
 	}
 }
 
@@ -218,21 +213,18 @@ func TestRouterSubscribe(t *testing.T) {
 
 	subscribeID := wamp.GlobalID()
 	sub.Send(&wamp.Subscribe{Request: subscribeID, Topic: testTopic})
-
-	var subscriptionID wamp.ID
-	select {
-	case <-time.After(time.Second):
+	msg, err := wamp.RecvTimeout(sub, time.Second)
+	if err != nil {
 		t.Fatal("Timed out waiting for SUBSCRIBED")
-	case msg := <-sub.Recv():
-		subMsg, ok := msg.(*wamp.Subscribed)
-		if !ok {
-			t.Fatal("Expected SUBSCRIBED, got:", msg.MessageType())
-		}
-		if subMsg.Request != subscribeID {
-			t.Fatal("wrong request ID")
-		}
-		subscriptionID = subMsg.Subscription
 	}
+	subMsg, ok := msg.(*wamp.Subscribed)
+	if !ok {
+		t.Fatal("Expected SUBSCRIBED, got:", msg.MessageType())
+	}
+	if subMsg.Request != subscribeID {
+		t.Fatal("wrong request ID")
+	}
+	subscriptionID := subMsg.Subscription
 
 	pub, err := testClient(r)
 	if err != nil {
@@ -241,17 +233,16 @@ func TestRouterSubscribe(t *testing.T) {
 	pubID := wamp.GlobalID()
 	pub.Send(&wamp.Publish{Request: pubID, Topic: testTopic})
 
-	select {
-	case <-time.After(time.Second):
+	msg, err = wamp.RecvTimeout(sub, time.Second)
+	if err != nil {
 		t.Fatal("Timed out waiting for EVENT")
-	case msg := <-sub.Recv():
-		event, ok := msg.(*wamp.Event)
-		if !ok {
-			t.Fatal("Expected EVENT, got:", msg.MessageType())
-		}
-		if event.Subscription != subscriptionID {
-			t.Fatal("wrong subscription ID")
-		}
+	}
+	event, ok := msg.(*wamp.Event)
+	if !ok {
+		t.Fatal("Expected EVENT, got:", msg.MessageType())
+	}
+	if event.Subscription != subscriptionID {
+		t.Fatal("wrong subscription ID")
 	}
 }
 
@@ -273,18 +264,17 @@ func TestPublishAcknowledge(t *testing.T) {
 		Options: wamp.Dict{"acknowledge": true},
 		Topic:   "some.uri"})
 
-	select {
-	case <-time.After(time.Second):
+	msg, err := wamp.RecvTimeout(client, time.Second)
+	if err != nil {
 		t.Fatal("sent acknowledge=true, timed out waiting for PUBLISHED")
-	case msg := <-client.Recv():
-		pub, ok := msg.(*wamp.Published)
-		if !ok {
-			t.Fatal("sent acknowledge=true, expected PUBLISHED, got:",
-				msg.MessageType())
-		}
-		if pub.Request != id {
-			t.Fatal("wrong request id")
-		}
+	}
+	pub, ok := msg.(*wamp.Published)
+	if !ok {
+		t.Fatal("sent acknowledge=true, expected PUBLISHED, got:",
+			msg.MessageType())
+	}
+	if pub.Request != id {
+		t.Fatal("wrong request id")
 	}
 }
 
@@ -305,9 +295,8 @@ func TestPublishFalseAcknowledge(t *testing.T) {
 		Options: wamp.Dict{"acknowledge": false},
 		Topic:   "some.uri"})
 
-	select {
-	case <-time.After(200 * time.Millisecond):
-	case msg := <-client.Recv():
+	msg, err := wamp.RecvTimeout(client, 200*time.Millisecond)
+	if err == nil {
 		if _, ok := msg.(*wamp.Published); ok {
 			t.Fatal("Sent acknowledge=false, but received PUBLISHED:",
 				msg.MessageType())
@@ -328,9 +317,8 @@ func TestPublishNoAcknowledge(t *testing.T) {
 
 	id := wamp.GlobalID()
 	client.Send(&wamp.Publish{Request: id, Topic: "some.uri"})
-	select {
-	case <-time.After(200 * time.Millisecond):
-	case msg := <-client.Recv():
+	msg, err := wamp.RecvTimeout(client, 200*time.Millisecond)
+	if err == nil {
 		if _, ok := msg.(*wamp.Published); ok {
 			t.Fatal("Sent acknowledge=false, but received PUBLISHED:",
 				msg.MessageType())
@@ -354,20 +342,18 @@ func TestRouterCall(t *testing.T) {
 	// Register remote procedure
 	callee.Send(&wamp.Register{Request: registerID, Procedure: testProcedure})
 
-	var registrationID wamp.ID
-	select {
-	case <-time.After(time.Second):
+	msg, err := wamp.RecvTimeout(callee, time.Second)
+	if err != nil {
 		t.Fatal("Timed out waiting for REGISTERED")
-	case msg := <-callee.Recv():
-		registered, ok := msg.(*wamp.Registered)
-		if !ok {
-			t.Fatal("expected REGISTERED,got:", msg.MessageType())
-		}
-		if registered.Request != registerID {
-			t.Fatal("wrong request ID")
-		}
-		registrationID = registered.Registration
 	}
+	registered, ok := msg.(*wamp.Registered)
+	if !ok {
+		t.Fatal("expected REGISTERED,got:", msg.MessageType())
+	}
+	if registered.Request != registerID {
+		t.Fatal("wrong request ID")
+	}
+	registrationID := registered.Registration
 
 	caller, err := testClient(r)
 	if err != nil {
@@ -377,35 +363,32 @@ func TestRouterCall(t *testing.T) {
 	// Call remote procedure
 	caller.Send(&wamp.Call{Request: callID, Procedure: testProcedure})
 
-	var invocationID wamp.ID
-	select {
-	case <-time.After(time.Second):
+	msg, err = wamp.RecvTimeout(callee, time.Second)
+	if err != nil {
 		t.Fatal("Timed out waiting for INVOCATION")
-	case msg := <-callee.Recv():
-		invocation, ok := msg.(*wamp.Invocation)
-		if !ok {
-			t.Fatal("expected INVOCATION, got:", msg.MessageType())
-		}
-		if invocation.Registration != registrationID {
-			t.Fatal("wrong registration id")
-		}
-		invocationID = invocation.Request
 	}
+	invocation, ok := msg.(*wamp.Invocation)
+	if !ok {
+		t.Fatal("expected INVOCATION, got:", msg.MessageType())
+	}
+	if invocation.Registration != registrationID {
+		t.Fatal("wrong registration id")
+	}
+	invocationID := invocation.Request
 
 	// Returns result of remove procedure
 	callee.Send(&wamp.Yield{Request: invocationID})
 
-	select {
-	case <-time.After(time.Second):
+	msg, err = wamp.RecvTimeout(caller, time.Second)
+	if err != nil {
 		t.Fatal("Timed out waiting for RESULT")
-	case msg := <-caller.Recv():
-		result, ok := msg.(*wamp.Result)
-		if !ok {
-			t.Fatal("expected RESULT, got", msg.MessageType())
-		}
-		if result.Request != callID {
-			t.Fatal("wrong result ID")
-		}
+	}
+	result, ok := msg.(*wamp.Result)
+	if !ok {
+		t.Fatal("expected RESULT, got", msg.MessageType())
+	}
+	if result.Request != callID {
+		t.Fatal("wrong result ID")
 	}
 }
 
@@ -422,24 +405,22 @@ func TestSessionMetaProcedures(t *testing.T) {
 		t.Fatal(err)
 	}
 	sessID := caller.ID
-	var result *wamp.Result
-	var ok bool
 
 	// Call session meta-procedure to get session count.
 	callID := wamp.GlobalID()
 	caller.Send(&wamp.Call{Request: callID, Procedure: wamp.MetaProcSessionCount})
-	select {
-	case <-time.After(time.Second):
-		t.Fatal("Timed out waiting for RESULT")
-	case msg := <-caller.Recv():
-		result, ok = msg.(*wamp.Result)
-		if !ok {
-			t.Fatal("expected RESULT, got", msg.MessageType())
-		}
-		if result.Request != callID {
-			t.Fatal("wrong result ID")
-		}
+	msg, err := wamp.RecvTimeout(caller, time.Second)
+	if err != nil {
+		t.Fatal(err)
 	}
+	result, ok := msg.(*wamp.Result)
+	if !ok {
+		t.Fatal("expected RESULT, got", msg.MessageType())
+	}
+	if result.Request != callID {
+		t.Fatal("wrong result ID")
+	}
+
 	if len(result.Arguments) == 0 {
 		t.Fatal("missing expected arguemnt")
 	}
@@ -454,18 +435,18 @@ func TestSessionMetaProcedures(t *testing.T) {
 	// Call session meta-procedure to get session list.
 	callID = wamp.GlobalID()
 	caller.Send(&wamp.Call{Request: callID, Procedure: wamp.MetaProcSessionList})
-	select {
-	case <-time.After(time.Second):
-		t.Fatal("Timed out waiting for RESULT")
-	case msg := <-caller.Recv():
-		result, ok = msg.(*wamp.Result)
-		if !ok {
-			t.Fatal("expected RESULT, got", msg.MessageType())
-		}
-		if result.Request != callID {
-			t.Fatal("wrong result ID")
-		}
+	msg, err = wamp.RecvTimeout(caller, time.Second)
+	if err != nil {
+		t.Fatal(err)
 	}
+	result, ok = msg.(*wamp.Result)
+	if !ok {
+		t.Fatal("expected RESULT, got", msg.MessageType())
+	}
+	if result.Request != callID {
+		t.Fatal("wrong result ID")
+	}
+
 	if len(result.Arguments) == 0 {
 		t.Fatal("missing expected arguemnt")
 	}
@@ -487,38 +468,35 @@ func TestSessionMetaProcedures(t *testing.T) {
 		Procedure: wamp.MetaProcSessionGet,
 		Arguments: wamp.List{wamp.ID(123456789)},
 	})
-	var errRsp *wamp.Error
-	select {
-	case <-time.After(time.Second):
-		t.Fatal("Timed out waiting for RESULT")
-	case msg := <-caller.Recv():
-		errRsp, ok = msg.(*wamp.Error)
-		if !ok {
-			t.Fatal("expected ERROR, got", msg.MessageType())
-		}
-		if errRsp.Error != wamp.ErrNoSuchSession {
-			t.Fatal("wrong error value")
-		}
+	msg, err = wamp.RecvTimeout(caller, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	errRsp, ok := msg.(*wamp.Error)
+	if !ok {
+		t.Fatal("expected ERROR, got", msg.MessageType())
+	}
+	if errRsp.Error != wamp.ErrNoSuchSession {
+		t.Fatal("wrong error value")
 	}
 
-	// Call session meta-procedure to get session get.
+	// Call session meta-procedure to get session information.
 	callID = wamp.GlobalID()
 	caller.Send(&wamp.Call{
 		Request:   callID,
 		Procedure: wamp.MetaProcSessionGet,
 		Arguments: wamp.List{sessID},
 	})
-	select {
-	case <-time.After(time.Second):
-		t.Fatal("Timed out waiting for RESULT")
-	case msg := <-caller.Recv():
-		result, ok = msg.(*wamp.Result)
-		if !ok {
-			t.Fatal("expected RESULT, got", msg.MessageType())
-		}
-		if result.Request != callID {
-			t.Fatal("wrong result ID")
-		}
+	msg, err = wamp.RecvTimeout(caller, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, ok = msg.(*wamp.Result)
+	if !ok {
+		t.Fatal("expected RESULT, got", msg.MessageType())
+	}
+	if result.Request != callID {
+		t.Fatal("wrong result ID")
 	}
 	if len(result.Arguments) == 0 {
 		t.Fatal("missing expected arguemnt")
@@ -546,23 +524,20 @@ func TestRegistrationMetaProcedures(t *testing.T) {
 		t.Fatal(err)
 	}
 	sessID := caller.ID
-	var result *wamp.Result
-	var ok bool
 
 	// ----- Test wamp.registration.list meta procedure -----
 	callID := wamp.GlobalID()
 	caller.Send(&wamp.Call{Request: callID, Procedure: wamp.MetaProcRegList})
-	select {
-	case <-time.After(time.Second):
+	msg, err := wamp.RecvTimeout(caller, time.Second)
+	if err != nil {
 		t.Fatal("Timed out waiting for RESULT")
-	case msg := <-caller.Recv():
-		result, ok = msg.(*wamp.Result)
-		if !ok {
-			t.Fatal("expected RESULT, got", msg.MessageType())
-		}
-		if result.Request != callID {
-			t.Fatal("wrong result ID")
-		}
+	}
+	result, ok := msg.(*wamp.Result)
+	if !ok {
+		t.Fatal("expected RESULT, got", msg.MessageType())
+	}
+	if result.Request != callID {
+		t.Fatal("wrong result ID")
 	}
 	if len(result.Arguments) == 0 {
 		t.Fatal("missing expected arguemnt")
@@ -593,21 +568,18 @@ func TestRegistrationMetaProcedures(t *testing.T) {
 	registerID := wamp.GlobalID()
 	callee.Send(&wamp.Register{Request: registerID, Procedure: testProcedure})
 
-	var registrationID wamp.ID
-	var registered *wamp.Registered
-	select {
-	case <-time.After(time.Second):
+	msg, err = wamp.RecvTimeout(callee, time.Second)
+	if err != nil {
 		t.Fatal("Timed out waiting for REGISTERED")
-	case msg := <-callee.Recv():
-		registered, ok = msg.(*wamp.Registered)
-		if !ok {
-			t.Fatal("expected REGISTERED, got:", msg.MessageType())
-		}
-		if registered.Request != registerID {
-			t.Fatal("wrong request ID")
-		}
-		registrationID = registered.Registration
 	}
+	registered, ok := msg.(*wamp.Registered)
+	if !ok {
+		t.Fatal("expected REGISTERED, got:", msg.MessageType())
+	}
+	if registered.Request != registerID {
+		t.Fatal("wrong request ID")
+	}
+	registrationID := registered.Registration
 
 	// Register remote procedure
 	callee.Send(&wamp.Register{
@@ -615,7 +587,7 @@ func TestRegistrationMetaProcedures(t *testing.T) {
 		Procedure: testProcedureWC,
 		Options:   wamp.Dict{"match": "wildcard"},
 	})
-	msg := <-callee.Recv()
+	msg = <-callee.Recv()
 	if _, ok = msg.(*wamp.Registered); !ok {
 		t.Fatal("expected REGISTERED, got:", msg.MessageType())
 	}
@@ -623,17 +595,16 @@ func TestRegistrationMetaProcedures(t *testing.T) {
 	// Call session meta-procedure to get session count.
 	callID = wamp.GlobalID()
 	caller.Send(&wamp.Call{Request: callID, Procedure: wamp.MetaProcRegList})
-	select {
-	case <-time.After(time.Second):
+	msg, err = wamp.RecvTimeout(caller, time.Second)
+	if err != nil {
 		t.Fatal("Timed out waiting for RESULT")
-	case msg := <-caller.Recv():
-		result, ok = msg.(*wamp.Result)
-		if !ok {
-			t.Fatal("expected RESULT, got", msg.MessageType())
-		}
-		if result.Request != callID {
-			t.Fatal("wrong result ID")
-		}
+	}
+	result, ok = msg.(*wamp.Result)
+	if !ok {
+		t.Fatal("expected RESULT, got", msg.MessageType())
+	}
+	if result.Request != callID {
+		t.Fatal("wrong result ID")
 	}
 	if len(result.Arguments) == 0 {
 		t.Fatal("missing expected arguemnt")
@@ -674,17 +645,16 @@ func TestRegistrationMetaProcedures(t *testing.T) {
 		Procedure: wamp.MetaProcRegLookup,
 		Arguments: wamp.List{testProcedure},
 	})
-	select {
-	case <-time.After(time.Second):
+	msg, err = wamp.RecvTimeout(caller, time.Second)
+	if err != nil {
 		t.Fatal("Timed out waiting for RESULT")
-	case msg := <-caller.Recv():
-		result, ok = msg.(*wamp.Result)
-		if !ok {
-			t.Fatal("expected RESULT, got", msg.MessageType())
-		}
-		if result.Request != callID {
-			t.Fatal("wrong result ID")
-		}
+	}
+	result, ok = msg.(*wamp.Result)
+	if !ok {
+		t.Fatal("expected RESULT, got", msg.MessageType())
+	}
+	if result.Request != callID {
+		t.Fatal("wrong result ID")
 	}
 	if len(result.Arguments) == 0 {
 		t.Fatal("missing expected arguemnt")
@@ -704,17 +674,16 @@ func TestRegistrationMetaProcedures(t *testing.T) {
 		Procedure: wamp.MetaProcRegMatch,
 		Arguments: wamp.List{testProcedure},
 	})
-	select {
-	case <-time.After(time.Second):
+	msg, err = wamp.RecvTimeout(caller, time.Second)
+	if err != nil {
 		t.Fatal("Timed out waiting for RESULT")
-	case msg := <-caller.Recv():
-		result, ok = msg.(*wamp.Result)
-		if !ok {
-			t.Fatal("expected RESULT, got", msg.MessageType())
-		}
-		if result.Request != callID {
-			t.Fatal("wrong result ID")
-		}
+	}
+	result, ok = msg.(*wamp.Result)
+	if !ok {
+		t.Fatal("expected RESULT, got", msg.MessageType())
+	}
+	if result.Request != callID {
+		t.Fatal("wrong result ID")
 	}
 	if len(result.Arguments) == 0 {
 		t.Fatal("missing expected arguemnt")
@@ -734,17 +703,16 @@ func TestRegistrationMetaProcedures(t *testing.T) {
 		Procedure: wamp.MetaProcRegGet,
 		Arguments: wamp.List{registrationID},
 	})
-	select {
-	case <-time.After(time.Second):
+	msg, err = wamp.RecvTimeout(caller, time.Second)
+	if err != nil {
 		t.Fatal("Timed out waiting for RESULT")
-	case msg := <-caller.Recv():
-		result, ok = msg.(*wamp.Result)
-		if !ok {
-			t.Fatalf("expected RESULT, got %s %+v", msg.MessageType(), msg)
-		}
-		if result.Request != callID {
-			t.Fatal("wrong result ID")
-		}
+	}
+	result, ok = msg.(*wamp.Result)
+	if !ok {
+		t.Fatalf("expected RESULT, got %s %+v", msg.MessageType(), msg)
+	}
+	if result.Request != callID {
+		t.Fatal("wrong result ID")
 	}
 	if len(result.Arguments) == 0 {
 		t.Fatal("missing expected arguemnt")
@@ -769,17 +737,16 @@ func TestRegistrationMetaProcedures(t *testing.T) {
 		Procedure: wamp.MetaProcRegListCallees,
 		Arguments: wamp.List{registrationID},
 	})
-	select {
-	case <-time.After(time.Second):
+	msg, err = wamp.RecvTimeout(caller, time.Second)
+	if err != nil {
 		t.Fatal("Timed out waiting for RESULT")
-	case msg := <-caller.Recv():
-		result, ok = msg.(*wamp.Result)
-		if !ok {
-			t.Fatal("expected RESULT, got", msg.MessageType())
-		}
-		if result.Request != callID {
-			t.Fatal("wrong result ID")
-		}
+	}
+	result, ok = msg.(*wamp.Result)
+	if !ok {
+		t.Fatal("expected RESULT, got", msg.MessageType())
+	}
+	if result.Request != callID {
+		t.Fatal("wrong result ID")
 	}
 	if len(result.Arguments) == 0 {
 		t.Fatal("missing expected arguemnt")
@@ -802,17 +769,16 @@ func TestRegistrationMetaProcedures(t *testing.T) {
 		Procedure: wamp.MetaProcRegCountCallees,
 		Arguments: wamp.List{registrationID},
 	})
-	select {
-	case <-time.After(time.Second):
+	msg, err = wamp.RecvTimeout(caller, time.Second)
+	if err != nil {
 		t.Fatal("Timed out waiting for RESULT")
-	case msg := <-caller.Recv():
-		result, ok = msg.(*wamp.Result)
-		if !ok {
-			t.Fatal("expected RESULT, got", msg.MessageType())
-		}
-		if result.Request != callID {
-			t.Fatal("wrong result ID")
-		}
+	}
+	result, ok = msg.(*wamp.Result)
+	if !ok {
+		t.Fatal("expected RESULT, got", msg.MessageType())
+	}
+	if result.Request != callID {
+		t.Fatal("wrong result ID")
 	}
 	if len(result.Arguments) == 0 {
 		t.Fatal("missing expected arguemnt")
@@ -851,13 +817,12 @@ func TestDynamicRealmChange(t *testing.T) {
 	}
 
 	cli.Send(&wamp.Goodbye{})
-	select {
-	case <-time.After(time.Second):
+	msg, err := wamp.RecvTimeout(cli, time.Second)
+	if err != nil {
 		t.Fatal("no goodbye message after sending goodbye")
-	case msg := <-cli.Recv():
-		if _, ok := msg.(*wamp.Goodbye); !ok {
-			t.Fatalf("expected GOODBYE, received %s", msg.MessageType())
-		}
+	}
+	if _, ok := msg.(*wamp.Goodbye); !ok {
+		t.Fatalf("expected GOODBYE, received %s", msg.MessageType())
 	}
 
 	cli, err = testClientInRealm(dr, testRealm2)

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -56,11 +56,12 @@ func newTestRouter() (Router, error) {
 	config := &Config{
 		RealmConfigs: []*RealmConfig{
 			{
-				URI:            testRealm,
-				StrictURI:      false,
-				AnonymousAuth:  true,
-				AllowDisclose:  false,
-				EnableMetaKill: true,
+				URI:              testRealm,
+				StrictURI:        false,
+				AnonymousAuth:    true,
+				AllowDisclose:    false,
+				EnableMetaKill:   true,
+				EnableMetaModify: true,
 			},
 		},
 		Debug: debug,

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -56,10 +56,11 @@ func newTestRouter() (Router, error) {
 	config := &Config{
 		RealmConfigs: []*RealmConfig{
 			{
-				URI:           testRealm,
-				StrictURI:     false,
-				AnonymousAuth: true,
-				AllowDisclose: false,
+				URI:            testRealm,
+				StrictURI:      false,
+				AnonymousAuth:  true,
+				AllowDisclose:  false,
+				EnableMetaKill: true,
 			},
 		},
 		Debug: debug,
@@ -501,11 +502,11 @@ func TestSessionMetaProcedures(t *testing.T) {
 	if len(result.Arguments) == 0 {
 		t.Fatal("missing expected arguemnt")
 	}
-	dict, ok := result.Arguments[0].(wamp.Dict)
+	details, ok := result.Arguments[0].(wamp.Dict)
 	if !ok {
 		t.Fatal("expected dict type arg")
 	}
-	sid, _ := wamp.AsID(dict["session"])
+	sid, _ := wamp.AsID(details["session"])
 	if sid != sessID {
 		t.Fatal("wrong session ID")
 	}

--- a/router/session.go
+++ b/router/session.go
@@ -1,0 +1,48 @@
+package router
+
+import (
+	"sync"
+
+	"github.com/gammazero/nexus/wamp"
+)
+
+// session is a wrapper around a wamp.Session to provide the router with a
+// lockable session.
+type session struct {
+	wamp.Session
+
+	rwlock sync.RWMutex
+}
+
+// newSession created a new lockable session.
+func newSession(peer wamp.Peer, sid wamp.ID, details wamp.Dict) *session {
+	return &session{
+		Session: wamp.Session{
+			Peer:    peer,
+			ID:      sid,
+			Details: details,
+		},
+	}
+}
+
+func (s *session) rLock()   { s.rwlock.RLock() }
+func (s *session) rUnlock() { s.rwlock.RUnlock() }
+func (s *session) lock()    { s.rwlock.Lock() }
+func (s *session) unlock()  { s.rwlock.Unlock() }
+
+// HasRole returns true if the session supports the specified role.
+func (s *session) HasRole(role string) bool {
+	s.rwlock.RLock()
+	ok := s.Session.HasRole(role)
+	s.rwlock.RUnlock()
+	return ok
+}
+
+// HasFeature returns true if the session has the specified feature for the
+// specified role.
+func (s *session) HasFeature(role, feature string) bool {
+	s.rwlock.RLock()
+	ok := s.Session.HasFeature(role, feature)
+	s.rwlock.RUnlock()
+	return ok
+}

--- a/router/session.go
+++ b/router/session.go
@@ -30,6 +30,9 @@ func (s *session) rUnlock() { s.rwlock.RUnlock() }
 func (s *session) lock()    { s.rwlock.Lock() }
 func (s *session) unlock()  { s.rwlock.Unlock() }
 
+// String returns the session ID as a string.
+func (s *session) String() string { return s.Session.String() }
+
 // HasRole returns true if the session supports the specified role.
 func (s *session) HasRole(role string) bool {
 	s.rwlock.RLock()

--- a/router/sessionkill_test.go
+++ b/router/sessionkill_test.go
@@ -34,6 +34,7 @@ func TestSessionKill(t *testing.T) {
 	reason := wamp.URI("foo.bar.baz")
 	message := "this is a test"
 
+	// Request that client-3 be killed.
 	cli1.Send(&wamp.Call{Request: wamp.GlobalID(), Procedure: wamp.MetaProcSessionKill, Arguments: wamp.List{cli3.ID}, ArgumentsKw: wamp.Dict{"reason": reason, "message": message}})
 
 	msg, err := wamp.RecvTimeout(cli1, time.Second)
@@ -45,6 +46,7 @@ func TestSessionKill(t *testing.T) {
 		t.Fatal("Expected RESULT, got", msg.MessageType())
 	}
 
+	// Check that client-3 received GOODBYE.
 	msg, err = wamp.RecvTimeout(cli3, time.Second)
 	if err != nil {
 		t.Fatal(err)
@@ -60,6 +62,7 @@ func TestSessionKill(t *testing.T) {
 		t.Error("Wrong message in GOODBYE, got", m, "expected", message)
 	}
 
+	// Check that client-2 did not get anything.
 	_, err = wamp.RecvTimeout(cli2, time.Millisecond)
 	if err == nil {
 		t.Fatal("Expected timeout")

--- a/router/sessionkill_test.go
+++ b/router/sessionkill_test.go
@@ -1,0 +1,241 @@
+package router
+
+import (
+	"testing"
+	"time"
+
+	"github.com/fortytw2/leaktest"
+	"github.com/gammazero/nexus/wamp"
+)
+
+func TestSessionKill(t *testing.T) {
+	defer leaktest.Check(t)()
+	r, err := newTestRouter()
+	if err != nil {
+		t.Error(err)
+	}
+	defer r.Close()
+
+	cli1, err := testClient(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cli2, err := testClient(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cli3, err := testClient(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reason := wamp.URI("foo.bar.baz")
+	message := "this is a test"
+
+	cli1.Send(&wamp.Call{Request: wamp.GlobalID(), Procedure: wamp.MetaProcSessionKill, Arguments: wamp.List{cli3.ID}, ArgumentsKw: wamp.Dict{"reason": reason, "message": message}})
+
+	msg, err := wamp.RecvTimeout(cli1, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, ok := msg.(*wamp.Result)
+	if !ok {
+		t.Fatal("Expected RESULT, got", msg.MessageType())
+	}
+
+	msg, err = wamp.RecvTimeout(cli3, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g, ok := msg.(*wamp.Goodbye)
+	if !ok {
+		t.Fatal("expected GOODBYE, got", msg.MessageType())
+	}
+	if g.Reason != reason {
+		t.Error("Wrong GOODBYE.Reason, got", g.Reason, "expected", reason)
+	}
+	if m, _ := wamp.AsString(g.Details["message"]); m != message {
+		t.Error("Wrong message in GOODBYE, got", m, "expected", message)
+	}
+
+	_, err = wamp.RecvTimeout(cli2, time.Millisecond)
+	if err == nil {
+		t.Fatal("Expected timeout")
+	}
+
+	// Test that killing self gets error.
+	cli1.Send(&wamp.Call{Request: wamp.GlobalID(), Procedure: wamp.MetaProcSessionKill, Arguments: wamp.List{cli1.ID}, ArgumentsKw: nil})
+
+	msg, err = wamp.RecvTimeout(cli1, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e, ok := msg.(*wamp.Error)
+	if !ok {
+		t.Fatal("Expected ERROR, got", msg.MessageType())
+	}
+	if e.Error != wamp.ErrNoSuchSession {
+		t.Error("Wrong error, got", e.Error, "expected", wamp.ErrNoSuchSession)
+	}
+
+	cli1.Close()
+	cli2.Close()
+}
+
+func TestSessionKillAll(t *testing.T) {
+	defer leaktest.Check(t)()
+	r, err := newTestRouter()
+	if err != nil {
+		t.Error(err)
+	}
+	defer r.Close()
+
+	cli1, err := testClient(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cli2, err := testClient(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cli3, err := testClient(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reason := wamp.URI("foo.bar.baz")
+	message := "this is a test"
+
+	cli1.Send(&wamp.Call{Request: wamp.GlobalID(), Procedure: wamp.MetaProcSessionKillAll, ArgumentsKw: wamp.Dict{"reason": reason, "message": message}})
+
+	msg, err := wamp.RecvTimeout(cli1, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, ok := msg.(*wamp.Result)
+	if !ok {
+		t.Fatal("Expected RESULT, got", msg.MessageType())
+	}
+
+	msg, err = wamp.RecvTimeout(cli2, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g, ok := msg.(*wamp.Goodbye)
+	if !ok {
+		t.Fatal("expected GOODBYE, got", msg.MessageType())
+	}
+	if g.Reason != reason {
+		t.Error("Wrong GOODBYE.Reason, got", g.Reason, "expected", reason)
+	}
+	if m, _ := wamp.AsString(g.Details["message"]); m != message {
+		t.Error("Wrong message in GOODBYE, got", m, "expected", message)
+	}
+
+	msg, err = wamp.RecvTimeout(cli3, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g, ok = msg.(*wamp.Goodbye)
+	if !ok {
+		t.Fatal("expected GOODBYE, got", msg.MessageType())
+	}
+	if g.Reason != reason {
+		t.Error("Wrong GOODBYE.Reason, got", g.Reason, "expected", reason)
+	}
+	if m, _ := wamp.AsString(g.Details["message"]); m != message {
+		t.Error("Wrong message in GOODBYE, got", m, "expected", message)
+	}
+
+	_, err = wamp.RecvTimeout(cli1, time.Millisecond)
+	if err == nil {
+		t.Fatal("Expected timeout")
+	}
+
+	cli1.Close()
+}
+
+func TestSessionKillByAuthid(t *testing.T) {
+	defer leaktest.Check(t)()
+	r, err := newTestRouter()
+	if err != nil {
+		t.Error(err)
+	}
+	defer r.Close()
+
+	cli1, err := testClient(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli1.Close()
+
+	cli2, err := testClient(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli2.Close()
+
+	cli3, err := testClient(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli3.Close()
+
+	reason := wamp.URI("foo.bar.baz")
+	message := "this is a test"
+
+	// All clients have the same authid, so killing by authid should kill all
+	// except the requesting client.
+	cli1.Send(&wamp.Call{Request: wamp.GlobalID(), Procedure: wamp.MetaProcSessionKillByAuthid, Arguments: wamp.List{cli1.Details["authid"]}, ArgumentsKw: wamp.Dict{"reason": reason, "message": message}})
+
+	msg, err := wamp.RecvTimeout(cli1, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, ok := msg.(*wamp.Result)
+	if !ok {
+		t.Fatal("Expected RESULT, got", msg.MessageType())
+	}
+
+	// Check that client 2 gets kicked off.
+	msg, err = wamp.RecvTimeout(cli2, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g, ok := msg.(*wamp.Goodbye)
+	if !ok {
+		t.Fatal("expected GOODBYE, got", msg.MessageType())
+	}
+	if g.Reason != reason {
+		t.Error("Wrong GOODBYE.Reason, got", g.Reason, "expected", reason)
+	}
+	if m, _ := wamp.AsString(g.Details["message"]); m != message {
+		t.Error("Wrong message in GOODBYE, got", m, "expected", message)
+	}
+
+	// Check that client 3 gets kicked off.
+	msg, err = wamp.RecvTimeout(cli3, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g, ok = msg.(*wamp.Goodbye)
+	if !ok {
+		t.Fatal("expected GOODBYE, got", msg.MessageType())
+	}
+	if g.Reason != reason {
+		t.Error("Wrong GOODBYE.Reason, got", g.Reason, "expected", reason)
+	}
+	if m, _ := wamp.AsString(g.Details["message"]); m != message {
+		t.Error("Wrong message in GOODBYE, got", m, "expected", message)
+	}
+
+	// Check that client 1 is not kicked off.
+	_, err = wamp.RecvTimeout(cli1, time.Millisecond)
+	if err == nil {
+		t.Fatal("Expected timeout")
+	}
+}

--- a/wamp/uris.go
+++ b/wamp/uris.go
@@ -36,16 +36,21 @@ const (
 
 	// -- Session Close --
 
+	CloseNormal = URI("wamp.close.normal")
+
 	// The Peer is shutting down completely - used as a GOODBYE (or ABORT)
 	// reason.
-	ErrSystemShutdown = URI("wamp.error.system_shutdown")
+	CloseSystemShutdown = URI("wamp.close.system_shutdown")
+	ErrSystemShutdown   = CloseSystemShutdown
 
 	// The Peer wants to leave the realm - used as a GOODBYE reason.
-	ErrCloseRealm = URI("wamp.error.close_realm")
+	CloseRealm    = URI("wamp.close.close_realm")
+	ErrCloseRealm = CloseRealm
 
 	// A Peer acknowledges ending of a session - used as a GOODBYE reply
 	// reason.
-	ErrGoodbyeAndOut = URI("wamp.error.goodbye_and_out")
+	CloseGoodbyeAndOut = URI("wamp.close.goodbye_and_out")
+	ErrGoodbyeAndOut   = CloseGoodbyeAndOut
 
 	// -- Authorization --
 
@@ -118,6 +123,21 @@ const (
 
 	// Retrieves information on a specific session.
 	MetaProcSessionGet = URI("wamp.session.get")
+
+	// Kill a single session identified by session ID.
+	MetaProcSessionKill = URI("wamp.session.kill")
+
+	// Kill all currently connected sessions that have the specified authid.
+	MetaProcSessionKillByAuthid = URI("wamp.session.kill_by_authid")
+
+	// Kill all currently connected sessions that have the specified authrole.
+	MetaProcSessionKillByAuthrole = URI("wamp.session.kill_by_authrole")
+
+	// Kill all currently connected sessions in the caller's realm.
+	MetaProcSessionKillAll = URI("wamp.session.kill_all")
+
+	// Modify details of session identified by session ID (non-standard).
+	MetaProcSessionModifyDetails = URI("wamp.session.modify_details")
 
 	// No session with the given ID exists on the router.
 	ErrNoSuchSession = URI("wamp.error.no_such_session")


### PR DESCRIPTION
The following new session meta procedures are implemented:
- `wamp.session.kill`
- `wamp.session.kill_by_authid`
- `wamp.session.kill_by_authrole`
- `wamp.session.kill_all`

A new non-standard session meta procedure is also available: `wamp.session.modify_details`.

Fixed a race condition that could occur when an Authorizer modified session details.