### PR TITLE
Dealer cancels progressive results if caller leaves realm

### DIFF
--- a/aat/rpcprogress_test.go
+++ b/aat/rpcprogress_test.go
@@ -33,19 +33,16 @@ func TestRPCProgressiveCallResults(t *testing.T) {
 		if e != nil {
 			fmt.Println("Error sending Alpha progress:", e)
 		}
-		time.Sleep(500 * time.Millisecond)
 
 		e = callee.SendProgress(ctx, wamp.List{"Bravo"}, nil)
 		if e != nil {
 			fmt.Println("Error sending Bravo progress:", e)
 		}
-		time.Sleep(500 * time.Millisecond)
 
 		e = callee.SendProgress(ctx, wamp.List{"Charlie"}, nil)
 		if e != nil {
 			fmt.Println("Error sending Charlie progress:", e)
 		}
-		time.Sleep(500 * time.Millisecond)
 
 		var sum int64
 		for i := range args {
@@ -108,5 +105,133 @@ func TestRPCProgressiveCallResults(t *testing.T) {
 	err = callee.Close()
 	if err != nil {
 		t.Fatal("Failed to disconnect client:", err)
+	}
+}
+
+// Test that killing the caller, while in the middle of receiving progressive
+// results, is handled correctly by both the closed caller and the callee.
+func TestRPCProgressiveCallInterrupt(t *testing.T) {
+	defer leaktest.Check(t)()
+	// Connect callee session.
+	callee, err := connectClient()
+	if err != nil {
+		t.Fatal("Failed to connect client:", err)
+	}
+
+	callerKiller := make(chan struct{})
+	callerClosed := make(chan struct{})
+	sentFinal := make(chan struct{})
+
+	// Handler sends progressive results.
+	var sendProgErr error
+	handler := func(ctx context.Context, args wamp.List, kwargs, details wamp.Dict) *client.InvokeResult {
+		defer close(sentFinal)
+		// Send a progressive result.  This should go through just fine.
+		e := callee.SendProgress(ctx, wamp.List{"Alpha"}, nil)
+		if e != nil {
+			fmt.Println("Error sending Alpha progress:", e)
+		}
+
+		// Give caller time to receive first message before closing.
+		time.Sleep(50 * time.Millisecond)
+		close(callerKiller)
+
+		// Wait for caller to close so that remaining messages will fail.
+		<-callerClosed
+
+		// This first result will cause the dealer to respond with INTERRUPT.
+		// An error is not returned here, since the result was sent to dealer.
+		e = callee.SendProgress(ctx, wamp.List{"Bravo"}, nil)
+		if e != nil {
+			fmt.Println("Error sending Bravo progress:", e)
+		}
+
+		// This second result will cause the dealer to respond with INTERRUPT
+		// if this client has not yet processed the INTERRUPT from the previous
+		// result.  If the result was sent to the dealer, then no error.
+		e = callee.SendProgress(ctx, wamp.List{"Charlie"}, nil)
+		if e != nil {
+			fmt.Println("Error sending progress:", e)
+		}
+
+		// Give time for this client to process INTERRUPTs.
+		//
+		// The client will process the first INTERRUPT and close the invocation
+		// handler.  The client will get the second INTERRUPT and see that the
+		// invocation no longer exists, and ignore the INTERRUPT.
+		time.Sleep(50 * time.Millisecond)
+
+		// This result will not be sent since the client has closed the
+		// invocation handler.  An error is returned saying "caller not
+		// accepting progressive results".
+		e = callee.SendProgress(ctx, wamp.List{"Delta"}, nil)
+		if e != nil && e.Error() != "caller not accepting progressive results" {
+			sendProgErr = fmt.Errorf("error sending progress: %s", e)
+		}
+
+		// This progressive result receives the same error as the previous.
+		e = callee.SendProgress(ctx, wamp.List{"Echo"}, nil)
+		if e != nil && e.Error() != "caller not accepting progressive results" {
+			sendProgErr = fmt.Errorf("error sending progress: %s", e)
+		}
+
+		// This goes nowhere (gets put in dead buffered channel), because the
+		// invocation handler has been closed and not handle the message.
+		return &client.InvokeResult{Args: wamp.List{"final"}}
+	}
+
+	// Register procedure
+	if err = callee.Register(progProc, handler, nil); err != nil {
+		t.Fatal("Failed to register procedure:", err)
+	}
+
+	// Connect caller session.
+	caller, err := connectClient()
+	if err != nil {
+		t.Fatal("Failed to connect client:", err)
+	}
+
+	progHandler := func(result *wamp.Result) {
+		arg := result.Arguments[0].(string)
+		fmt.Println("Caller received progress response:", arg)
+	}
+
+	// Test calling the procedure.
+	var recvProgErr error
+	go func() {
+		ctx := context.Background()
+		_, e := caller.CallProgress(ctx, progProc, nil, nil, nil, "", progHandler)
+		if e != nil && e.Error() != "client closed" {
+			recvProgErr = fmt.Errorf(
+				"unexpected error returned from CallProgress: %s", e)
+		}
+	}()
+
+	// Wait for progressive results to start being returned, then kill caller.
+	<-callerKiller
+	err = caller.Close()
+	if err != nil {
+		t.Error("Failed to disconnect client:", err)
+	}
+	if recvProgErr != nil {
+		t.Error(recvProgErr)
+	}
+	close(callerClosed)
+
+	select {
+	case <-sentFinal:
+		t.Error("Callee should not have finished sending progressive results")
+	default:
+	}
+
+	<-sentFinal
+
+	if sendProgErr != nil {
+		t.Error(sendProgErr)
+	}
+
+	err = callee.Close()
+	if err != nil {
+		t.Error("Failed to disconnect client:", err)
 	}
 }

--- a/aat/rpcprogress_test.go
+++ b/aat/rpcprogress_test.go
@@ -167,6 +167,9 @@ func TestRPCProgressiveCallInterrupt(t *testing.T) {
 		e = callee.SendProgress(ctx, wamp.List{"Delta"}, nil)
 		if e != nil && e.Error() != "caller not accepting progressive results" {
 			sendProgErr = fmt.Errorf("error sending progress: %s", e)
+			// Normally the callee should cancel the call, but this test makes
+			// sure a callee that keeps trying to send is handled correctly.
+			//return &client.InvokeResult{Err: wamp.ErrCanceled}
 		}
 
 		// This progressive result receives the same error as the previous.

--- a/examples/rpc_progressive_results/callee/callee.go
+++ b/examples/rpc_progressive_results/callee/callee.go
@@ -1,0 +1,110 @@
+/*
+Progressive Call Results Example Callee
+
+This example demonstrates a callee client that sends data in chunks, as
+separate progressive call results.  A callee may do this to send a large body
+of data in managable chunks, or to deliver some portion of the result more
+immediately.
+
+In this example, the progressive results are portions of a larger body of text.
+The final result is a sha256 sum of all the data, allowing the caller to verify
+that it received everything correcly.
+
+*/
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"log"
+	"os"
+	"os/signal"
+
+	"github.com/gammazero/nexus/client"
+	"github.com/gammazero/nexus/examples/newclient"
+	"github.com/gammazero/nexus/wamp"
+)
+
+const procedureName = "example.progress.text"
+
+func main() {
+	logger := log.New(os.Stdout, "CALLEE> ", 0)
+	// Connect callee client with requested socket type and serialization.
+	callee, err := newclient.NewClient(logger)
+	if err != nil {
+		logger.Fatal(err)
+	}
+	defer callee.Close()
+
+	// Handler is a closure used to capture the callee, since this is not
+	// provided as a parameter to this callback.
+	handler := func(ctx context.Context, args wamp.List, kwargs, details wamp.Dict) *client.InvokeResult {
+		return sendData(ctx, callee, args)
+	}
+
+	// Register procedure.
+	if err = callee.Register(procedureName, handler, nil); err != nil {
+		logger.Fatal("Failed to register procedure:", err)
+	}
+	logger.Println("Registered procedure", procedureName, "with router")
+
+	// Wait for CTRL-c or client close while handling remote procedure calls.
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+	select {
+	case <-sigChan:
+	case <-callee.Done():
+		logger.Print("Router gone, exiting")
+		return // router gone, just exit
+	}
+
+	if err = callee.Unregister(procedureName); err != nil {
+		logger.Println("Failed to unregister procedure:", err)
+	}
+}
+
+// sendData sends the body of data in chunks of the requested size.  The final
+// result message contains the sha256 hash of the data to allow the caller to
+// verify that all the data was correctly received.
+func sendData(ctx context.Context, callee *client.Client, args wamp.List) *client.InvokeResult {
+	// Compute the base64-encoded sha256 hash of the data.
+	h := sha256.New()
+	h.Write([]byte(gettysburg))
+	hash64 := base64.StdEncoding.EncodeToString(h.Sum(nil))
+
+	// Put data in buffer to read chunks from.
+	b := bytes.NewBuffer([]byte(gettysburg))
+
+	// Get chunksize requested by caller, use default if not set.
+	var chunkSize int
+	if len(args) != 0 {
+		i, _ := wamp.AsInt64(args[0])
+		chunkSize = int(i)
+	}
+	if chunkSize == 0 {
+		chunkSize = 64
+	}
+
+	// Read and send chunks of data until the buffer is empty.
+	for chunk := b.Next(chunkSize); len(chunk) != 0; chunk = b.Next(chunkSize) {
+		// Send a chunk of data.
+		err := callee.SendProgress(ctx, wamp.List{string(chunk)}, nil)
+		if err != nil {
+			// If send failed, return an error saying the call canceled.
+			return &client.InvokeResult{Err: wamp.ErrCanceled}
+		}
+	}
+
+	// Send sha256 hash as final result.
+	return &client.InvokeResult{Args: wamp.List{hash64}}
+}
+
+// This is the body of data that is sent in chunks.
+var gettysburg = `Four score and seven years ago our fathers brought forth on this continent, a new nation, conceived in Liberty, and dedicated to the proposition that all men are created equal.
+
+Now we are engaged in a great civil war, testing whether that nation, or any nation so conceived and dedicated, can long endure. We are met on a great battle-field of that war. We have come to dedicate a portion of that field, as a final resting place for those who here gave their lives that that nation might live. It is altogether fitting and proper that we should do this.
+
+But, in a larger sense, we can not dedicate -- we can not consecrate -- we can not hallow -- this ground. The brave men, living and dead, who struggled here, have consecrated it, far above our poor power to add or detract. The world will little note, nor long remember what we say here, but it can never forget what they did here. It is for us the living, rather, to be dedicated here to the unfinished work which they who fought here have thus far so nobly advanced. It is rather for us to be here dedicated to the great task remaining before us -- that from these honored dead we take increased devotion to that cause for which they gave the last full measure of devotion -- that we here highly resolve that these dead shall not have died in vain -- that this nation, under God, shall have a new birth of freedom -- and that government of the people, by the people, for the people, shall not perish from the earth.`

--- a/examples/rpc_progressive_results/caller/caller.go
+++ b/examples/rpc_progressive_results/caller/caller.go
@@ -1,0 +1,88 @@
+/*
+Progressive Call Results Example Caller
+
+This example demonstrates a caller client that receives data in chunks, as
+separate progressive call results.  A caller may do this to receive a large
+body of data in managable chunks, or to deliver some portion of the result more
+immediately.
+
+In this example, the progressive results are portions of a larger body of text.
+The final result is a sha256 sum of all the data, allowing the caller to verify
+that it received everything correcly.
+
+*/
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/gammazero/nexus/examples/newclient"
+	"github.com/gammazero/nexus/wamp"
+)
+
+const (
+	// Example procedure name.
+	procedureName = "example.progress.text"
+	// Chunk size example caller requests.
+	chunkSize = int64(64)
+)
+
+func main() {
+	logger := log.New(os.Stderr, "CALLER> ", 0)
+
+	// Connect caller client with requested socket type and serialization.
+	caller, err := newclient.NewClient(logger)
+	if err != nil {
+		logger.Fatal(err)
+	}
+	defer caller.Close()
+
+	// The progress handler accumulates the chunks of data as they arrive.  It
+	// also progressively calculates a sha256 hash of the data as it arrives.
+	var chunks []string
+	h := sha256.New()
+	progHandler := func(result *wamp.Result) {
+		// Received another chunk of data, computing hash as chunks received.
+		chunk := result.Arguments[0].(string)
+		logger.Println("Received", len(chunk), "bytes (as progressive result)")
+		chunks = append(chunks, chunk)
+		h.Write([]byte(chunk))
+	}
+
+	ctx := context.Background()
+
+	// Call the example procedure with args 1..10.  The procedure will
+	// return the result of a different calculation with each progressive
+	// result.
+	result, err := caller.CallProgress(
+		ctx, procedureName, nil, wamp.List{chunkSize}, nil, "", progHandler)
+	if err != nil {
+		logger.Println("Failed to call procedure:", err)
+		return
+	}
+
+	// As a final result, the callee returns the base64 encoded sha256 hash of
+	// the data.  This is decoded and compared to the value that the caller
+	// calculated.  If they match, then the caller recieved the data correctly.
+	hashB64 := result.Arguments[0].(string)
+	calleeHash, err := base64.StdEncoding.DecodeString(hashB64)
+	if err != nil {
+		logger.Println("decode error:", err)
+		return
+	}
+
+	// Check if rceived hash matches the hash computed over the received data.
+	if !bytes.Equal(calleeHash, h.Sum(nil)) {
+		logger.Println("Hash of received data does not match")
+		return
+	}
+	logger.Println("Correctly received all data:")
+	logger.Println("----------------------------")
+	logger.Println(strings.Join(chunks, ""))
+}

--- a/router/dealer.go
+++ b/router/dealer.go
@@ -850,7 +850,7 @@ func (d *Dealer) error(msg *wamp.Error) {
 }
 
 func (d *Dealer) removeSession(sess *session) {
-	// Remove and remaining registrations for the removed session.
+	// Remove any remaining registrations for the removed session.
 	for regID := range d.calleeRegIDSet[sess] {
 		delReg, err := d.delCalleeReg(sess, regID)
 		if err != nil {
@@ -884,7 +884,7 @@ func (d *Dealer) removeSession(sess *session) {
 	}
 	delete(d.calleeRegIDSet, sess)
 
-	// Remove any pending calls for the removed session
+	// Remove any pending calls for the removed session.
 	for req, caller := range d.calls {
 		if caller != sess {
 			continue

--- a/router/realm.go
+++ b/router/realm.go
@@ -393,9 +393,12 @@ func (r *realm) onLeave(sess *session, shutdown, killAll bool) {
 		sendTestaments(testaments.destroyed)
 	}
 	r.metaPeer.Send(&wamp.Publish{
-		Request:   wamp.GlobalID(),
-		Topic:     wamp.MetaEventSessionOnLeave,
-		Arguments: wamp.List{sess.ID},
+		Request: wamp.GlobalID(),
+		Topic:   wamp.MetaEventSessionOnLeave,
+		Arguments: wamp.List{
+			sess.ID,
+			sess.Details["authid"],
+			sess.Details["authrole"]},
 	})
 }
 

--- a/transport/serialize/serializer_test.go
+++ b/transport/serialize/serializer_test.go
@@ -34,6 +34,7 @@ func detailRolesFeatures() wamp.Dict {
 			"callee":     wamp.Dict{},
 			"caller":     wamp.Dict{},
 		},
+		"nothere": nil,
 	}
 }
 
@@ -59,6 +60,14 @@ func TestJSONSerialize(t *testing.T) {
 	}
 	if !hasFeature(hello.Details, "publisher", "subscriber_blackwhite_listing") {
 		t.Fatal("did not deserialize message details")
+	}
+
+	val, ok := hello.Details["nothere"]
+	if !ok {
+		t.Fatal("nil value item 'nothere' is missing")
+	}
+	if val != nil {
+		t.Fatal("expected nil value item 'nothere'")
 	}
 }
 
@@ -102,6 +111,14 @@ func TestCBORSerialize(t *testing.T) {
 	}
 	if !hasFeature(hello.Details, "publisher", "subscriber_blackwhite_listing") {
 		t.Fatal("did not deserialize message details")
+	}
+
+	val, ok := hello.Details["nothere"]
+	if !ok {
+		t.Fatal("nil value item 'nothere' is missing")
+	}
+	if val != nil {
+		t.Fatal("expected nil value item 'nothere'")
 	}
 }
 
@@ -156,6 +173,14 @@ func TestMessagePackSerialize(t *testing.T) {
 	}
 	if !hasFeature(hello.Details, "publisher", "subscriber_blackwhite_listing") {
 		t.Fatal("did not deserialize message details")
+	}
+
+	val, ok := hello.Details["nothere"]
+	if !ok {
+		t.Fatal("nil value item 'nothere' is missing")
+	}
+	if val != nil {
+		t.Fatal("expected nil value item 'nothere'")
 	}
 }
 

--- a/transport/websocketpeer.go
+++ b/transport/websocketpeer.go
@@ -147,7 +147,13 @@ func (w *websocketPeer) Recv() <-chan wamp.Message { return w.rd }
 func (w *websocketPeer) TrySend(msg wamp.Message) error {
 	select {
 	case w.wr <- msg:
+		return nil
 	default:
+	}
+
+	select {
+	case w.wr <- msg:
+	case <-time.After(time.Second):
 		return errors.New("blocked")
 	}
 	return nil


### PR DESCRIPTION
- Send INTERRUPT to callee to stop progressive results if caller left realm
- Disable progressive call results feature of callees that do not support call cancelling
- Cleanup pending calls and invocations when client leaves realm
- Additional arguments in wamp.session.on_leave event
- Test interrupting progressive results in the middle by closing caller
- Cleanup invocation handlers if client closes during RPC handling
- Return error to call if caller closed while waiting on call result