### PR TITLE
Fix prefix/wildcard invocation handling

### DIFF
--- a/router/dealer.go
+++ b/router/dealer.go
@@ -627,8 +627,7 @@ func (d *Dealer) call(caller *session, msg *wamp.Call) {
 					Details: wamp.Dict{},
 					Error:   wamp.ErrOptionDisallowedDiscloseMe,
 				})
-			}
-			if callee.HasFeature(roleCallee, featureCallerIdent) {
+			} else if callee.HasFeature(roleCallee, featureCallerIdent) {
 				discloseCaller(caller, details)
 			}
 		}

--- a/router/dealer.go
+++ b/router/dealer.go
@@ -516,7 +516,7 @@ func (d *Dealer) matchProcedure(procedure wamp.URI) (*registration, bool) {
 		// No exact match was found.  So, search for a prefix or wildcard
 		// match, and prefer the most specific math (longest matched pattern).
 		// If there is a tie, then prefer the first longest prefix.
-		var matchCount int
+		matchCount := -1 // initialize matchCount to -1 to catch an empty registration.
 		for pfxProc, pfxReg := range d.pfxProcRegMap {
 			if procedure.PrefixMatch(pfxProc) {
 				if len(pfxProc) > matchCount {
@@ -526,6 +526,12 @@ func (d *Dealer) matchProcedure(procedure wamp.URI) (*registration, bool) {
 				}
 			}
 		}
+		// according to the spec, we have to prefer prefix match over wildcard match:
+		// https://wamp-proto.org/static/rfc/draft-oberstet-hybi-crossbar-wamp.html#rfc.section.14.3.8.1.4.2
+		if ok {
+			return reg, ok
+		}
+
 		for wcProc, wcReg := range d.wcProcRegMap {
 			if procedure.WildcardMatch(wcProc) {
 				if len(wcProc) > matchCount {

--- a/router/dealer.go
+++ b/router/dealer.go
@@ -627,7 +627,10 @@ func (d *Dealer) call(caller *session, msg *wamp.Call) {
 					Details: wamp.Dict{},
 					Error:   wamp.ErrOptionDisallowedDiscloseMe,
 				})
-			} else if callee.HasFeature(roleCallee, featureCallerIdent) {
+				// don't continue a call when discloseMe was disallowed.
+				return
+			}
+			if callee.HasFeature(roleCallee, featureCallerIdent) {
 				discloseCaller(caller, details)
 			}
 		}
@@ -642,6 +645,11 @@ func (d *Dealer) call(caller *session, msg *wamp.Call) {
 		if callee.HasFeature(roleCallee, featureProgCallResults) {
 			details[wamp.OptReceiveProgress] = true
 		}
+	}
+
+	if reg.match != wamp.MatchExact {
+		// according to the spec, a router has to provide the actual procedure to the client.
+		details[wamp.OptProcedure] = msg.Procedure
 	}
 
 	d.calls[msg.Request] = caller

--- a/router/dealer_test.go
+++ b/router/dealer_test.go
@@ -962,7 +962,9 @@ func TestPatternBasedRegistration(t *testing.T) {
 		&wamp.Register{
 			Request:   123,
 			Procedure: testProcedureWC,
-			Options:   wamp.Dict{"match": "wildcard"},
+			Options: wamp.Dict{
+				wamp.OptMatch: wamp.MatchWildcard,
+			},
 		})
 	rsp := <-callee.Recv()
 	_, ok := rsp.(*wamp.Registered)

--- a/wamp/options.go
+++ b/wamp/options.go
@@ -11,6 +11,7 @@ const (
 	OptInvoke          = "invoke"
 	OptMatch           = "match"
 	OptMode            = "mode"
+	OptProcedure       = "procedure"
 	OptProgress        = "progress"
 	OptReceiveProgress = "receive_progress"
 	OptTimeout         = "timeout"


### PR DESCRIPTION
A prefix registration was ignored when the prefix was empty.
Additionally, the spec requires a router to prefer prefix matches over wildcard matches and send the actual procedure the client tried to call as `procedure` field in the details dict.