### PR TITLE
Ugorji changed their API and broke msgpackserializer

### DIFF
--- a/transport/serialize/msgpackserializer.go
+++ b/transport/serialize/msgpackserializer.go
@@ -11,10 +11,9 @@ import (
 var mh *codec.MsgpackHandle
 
 func init() {
-	mh = &codec.MsgpackHandle{
-		RawToString: true,
-		WriteExt:    true,
-	}
+	mh = new(codec.MsgpackHandle)
+	mh.RawToString = true
+	mh.WriteExt = true
 	mh.MapType = reflect.TypeOf(map[string]interface{}(nil))
 }
 


### PR DESCRIPTION
Earlier today https://github.com/ugorji/go pushed a commit (https://github.com/ugorji/go/commit/a70535d8491cc93f3813e0946f4399501f3cb47f) that changed the placement of the `RawToString` bool from inside the `MsgpackHandle` to inside the `DecodeOptions` type.  This caused my builds to start failing due to https://github.com/gammazero/nexus/blob/master/transport/serialize/msgpackserializer.go#L14.

This PR is a non-breaking change that corrects this issue by setting the fields post struct construction. 