### PR TITLE
Discard YIELD if it comes from the wrong session

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,4 +42,4 @@ $(SERVICE_DIR)/nexusd:
 clean:
 	@rm -f $(SERVICE_DIR)/nexusd
 	@rm -f $(SERVICE_DIR)/*.log
-	@go clean
+	@GO111MODULE=off go clean

--- a/router/dealer.go
+++ b/router/dealer.go
@@ -821,7 +821,6 @@ func (d *Dealer) yield(callee *session, msg *wamp.Yield) {
 
 	// Make sure this yield was sent by the session that handled the call
 	if invk.callee != callee {
-		d.log.Println("DIFF CALLEES:", invk.callee, callee)
 		d.log.Println("Ignoring YIELD received from session", callee, "that does not own request", msg.Request)
 		return
 	}

--- a/router/dealer.go
+++ b/router/dealer.go
@@ -683,8 +683,8 @@ func (d *Dealer) call(caller *session, msg *wamp.Call) {
 	d.invocations[invocationID] = &invocation{
 		callID: reqID,
 		callee: callee,
-}
-d.invocationByCall[reqID] = invocationID
+	}
+	d.invocationByCall[reqID] = invocationID
 
 	// Send INVOCATION to the endpoint that has registered the requested
 	// procedure.
@@ -818,6 +818,14 @@ func (d *Dealer) yield(callee *session, msg *wamp.Yield) {
 		}
 		return
 	}
+
+	// Make sure this yield was sent by the session that handled the call
+	if invk.callee != callee {
+		d.log.Println("DIFF CALLEES:", invk.callee, callee)
+		d.log.Println("Ignoring YIELD received from session", callee, "that does not own request", msg.Request)
+		return
+	}
+
 	callID := invk.callID
 	// Find caller for this result.
 	caller, ok := d.calls[callID]

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -417,10 +417,11 @@ func TestSessionMetaProcedures(t *testing.T) {
 		// Call with extra arguments (but invalid)
 		&wamp.Call{Request: wamp.GlobalID(), Procedure: wamp.MetaProcSessionCount, Arguments: wamp.List{"invalidarg"}},
 	}
+	var msg wamp.Message
 	for _, req := range sessionCountRequests {
 		callID := req.Request
 		caller.Send(req)
-		msg, err := wamp.RecvTimeout(caller, time.Second)
+		msg, err = wamp.RecvTimeout(caller, time.Second)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -454,7 +455,7 @@ func TestSessionMetaProcedures(t *testing.T) {
 	for _, req := range sessionListRequests {
 		callID := req.Request
 		caller.Send(&wamp.Call{Request: callID, Procedure: wamp.MetaProcSessionList})
-		msg, err := wamp.RecvTimeout(caller, time.Second)
+		msg, err = wamp.RecvTimeout(caller, time.Second)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -488,7 +489,7 @@ func TestSessionMetaProcedures(t *testing.T) {
 		Procedure: wamp.MetaProcSessionGet,
 		Arguments: wamp.List{wamp.ID(123456789)},
 	})
-	msg, err := wamp.RecvTimeout(caller, time.Second)
+	msg, err = wamp.RecvTimeout(caller, time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/router/session.go
+++ b/router/session.go
@@ -15,8 +15,12 @@ type session struct {
 	rwlock   sync.RWMutex
 }
 
-// newSession created a new lockable session.
+// newSession creates a new lockable session.
 func newSession(peer wamp.Peer, sid wamp.ID, details wamp.Dict) *session {
+	if sid == 0 {
+		sid = wamp.GlobalID()
+	}
+
 	return &session{
 		Session: wamp.Session{
 			Peer:    peer,


### PR DESCRIPTION
A YIELD message should only come from the session to which the CALL was sent.  If any other session sends a YEILD for that CALL, then the YIELD is discarded and the error is logged.

Added unit test for above.  Made additional fixes to existing unit tests.