### PR TITLE
Fix issue #189

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1293,8 +1293,8 @@ func (c *Client) runHandleInvocation(msg *wamp.Invocation) {
 
 			c.runAction(func() {
 				delete(c.invHandlerKill, msg.Request)
-				c.activeInvHandlers.Done()
 			})
+			c.activeInvHandlers.Done()
 		}()
 
 		// Wait for the handler to finish or for the call be to canceled.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -51,6 +51,7 @@ func connectedTestClients() (*Client, *Client, router.Router, error) {
 		AnonymousAuth:    true,
 		AllowDisclose:    true,
 		RequireLocalAuth: true,
+		EnableMetaKill:   true,
 	}
 	r, err := getTestRouter(realmConfig)
 	if err != nil {
@@ -311,7 +312,7 @@ func TestRemoteProcedureCall(t *testing.T) {
 
 	// Test getting registration ID.
 	if _, ok := callee.RegistrationID(procName); !ok {
-		t.Fatal("Did not get subscription ID")
+		t.Fatal("Did not get registration ID")
 	}
 	if _, ok := callee.RegistrationID("no.such.procedure"); ok {
 		t.Fatal("Expected !ok looking up registration ID for bad procedure")
@@ -836,4 +837,64 @@ func TestClientRace(t *testing.T) {
 	r.Close()
 	killer.Close()
 	callee.Close()
+}
+
+// Test that if the router disconnects the client, while the client is running
+// and invocation handler, that the handler still get marked as done when it
+// completes.
+func TestInvocationHandlerMissedDone(t *testing.T) {
+	//defer leaktest.Check(t)()
+
+	// Connect two clients to the same server
+	callee, caller, r, err := connectedTestClients()
+	if err != nil {
+		t.Fatal("failed to connect test clients:", err)
+	}
+
+	calledChan := make(chan struct{})
+
+	// Register procedure.
+	handler := func(ctx context.Context, args wamp.List, kwargs, details wamp.Dict) *InvokeResult {
+		close(calledChan)
+		<-ctx.Done()
+		time.Sleep(2 * time.Second)
+		return &InvokeResult{Args: wamp.List{args[0].(int) * 37}}
+	}
+	procName := "myproc"
+	if err = callee.Register(procName, handler, nil); err != nil {
+		t.Fatal("failed to register procedure:", err)
+	}
+
+	// Call procedure
+	callArgs := wamp.List{73}
+	ctx := context.Background()
+
+	go caller.Call(ctx, procName, nil, callArgs, nil, "")
+
+	<-calledChan
+
+	killArgs := wamp.List{callee.ID()}
+	killKwArgs := wamp.Dict{"reason": "com.session.kill", "message": "because i can"}
+	var result *wamp.Result
+	result, err = caller.Call(ctx, string(wamp.MetaProcSessionKill), nil, killArgs, killKwArgs, "")
+	if err != nil {
+		t.Log("Kill new client failed:", err)
+	}
+	if result == nil {
+		t.Log("Kill new client returned no result")
+	}
+
+	caller.Close()
+
+	done := make(chan struct{})
+	go func() {
+		callee.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out waiting to close client")
+	}
+	r.Close()
 }

--- a/router/dealer.go
+++ b/router/dealer.go
@@ -29,7 +29,7 @@ const (
 	// CALL timeout which spedifies how long the callee may take to answer.
 	sendResultDeadline = time.Minute
 	// yieldRetryDelay is the initial delay before reprocessin a blocked yield
-	yieldRetryDelay = 200 * time.Millisecond
+	yieldRetryDelay = time.Millisecond
 )
 
 // Role information for this broker.
@@ -332,7 +332,7 @@ func (d *Dealer) Cancel(caller *session, msg *wamp.Cancel) {
 // Yield handles the result of successfully processing and finishing the
 // execution of a call, send from callee to dealer.
 //
-// If the RESULT could not be sent to the caller because he caller was blocked
+// If the RESULT could not be sent to the caller because the caller was blocked
 // (send queue full), then retry sending until timeout.  If timeout while
 // trying to send RESULT, then cancel call.
 func (d *Dealer) Yield(callee *session, msg *wamp.Yield) {
@@ -354,7 +354,9 @@ func (d *Dealer) Yield(callee *session, msg *wamp.Yield) {
 		start := time.Now()
 		// Retry processing YIELD until caller gone or deadline reached
 		for {
-			d.log.Println("Retry sending RESULT after", delay)
+			if d.debug {
+				d.log.Println("Retry sending RESULT after", delay)
+			}
 			<-time.After(delay)
 			// Do not retry if the elapsed time exceeds deadline
 			if time.Since(start) >= sendResultDeadline {


### PR DESCRIPTION
Always signal when an invocation handler has finished.  Includes unit test of router that disconnects callee during invocation handling.