### PR TITLE
Check client connection before sending message

### DIFF
--- a/aat/rpc_progress_test.go
+++ b/aat/rpc_progress_test.go
@@ -137,7 +137,6 @@ func TestRPCProgressiveCallInterrupt(t *testing.T) {
 
 		// Give caller time to receive first message before closing.
 		time.Sleep(50 * time.Millisecond)
-		close(callerKiller)
 
 		// Wait for caller to close so that remaining messages will fail.
 		<-callerClosed
@@ -200,28 +199,33 @@ func TestRPCProgressiveCallInterrupt(t *testing.T) {
 	progHandler := func(result *wamp.Result) {
 		arg := result.Arguments[0].(string)
 		fmt.Println("Caller received progress response:", arg)
+		select {
+		case callerKiller <- struct{}{}:
+		default:
+		}
 	}
 
 	// Test calling the procedure.
-	var recvProgErr error
+	recvProgErr := make(chan error)
 	go func() {
 		ctx := context.Background()
 		_, e := caller.CallProgress(ctx, progProc, nil, nil, nil, "", progHandler)
-		if e != nil && e.Error() != "client closed" {
-			recvProgErr = fmt.Errorf(
-				"unexpected error returned from CallProgress: %s", e)
-		}
+		recvProgErr <- e
 	}()
 
 	// Wait for progressive results to start being returned, then kill caller.
 	<-callerKiller
+
 	err = caller.Close()
 	if err != nil {
 		t.Error("Failed to disconnect client:", err)
 	}
-	if recvProgErr != nil {
-		t.Error(recvProgErr)
+
+	err = <-recvProgErr
+	if err != client.ErrNotConn {
+		t.Errorf("unexpected error returned fom CallProgress: %s", err)
 	}
+	<-caller.Done()
 	close(callerClosed)
 
 	select {

--- a/client/client.go
+++ b/client/client.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/gammazero/nexus/stdlog"
@@ -85,15 +84,15 @@ type Client struct {
 	invHandlerKill map[wamp.ID]context.CancelFunc
 	progGate       map[context.Context]wamp.ID
 
-	stopping          chan struct{}
 	activeInvHandlers sync.WaitGroup
 
 	log   stdlog.StdLog
 	debug bool
 
-	closed    int32
-	done      chan struct{}
-	connected bool
+	cancel context.CancelFunc
+	ctx    context.Context
+
+	closed bool
 
 	routerGoodbye *wamp.Goodbye
 	idGen         *wamp.SyncIDGen
@@ -137,21 +136,22 @@ func NewClient(p wamp.Peer, cfg Config) (*Client, error) {
 		invHandlerKill: map[wamp.ID]context.CancelFunc{},
 		progGate:       map[context.Context]wamp.ID{},
 
-		stopping:  make(chan struct{}),
-		done:      make(chan struct{}),
-		connected: true,
-
 		log:   cfg.Logger,
 		debug: cfg.Debug,
 		idGen: new(wamp.SyncIDGen),
 	}
+	c.ctx, c.cancel = context.WithCancel(context.Background())
 	go c.run() // start the core goroutine
 	return c, nil
 }
 
 // Done returns a channel that signals when the client is no longer connected
 // to a router and has shutdown.
-func (c *Client) Done() <-chan struct{} { return c.done }
+func (c *Client) Done() <-chan struct{} { return c.ctx.Done() }
+
+// Connected returns true if the client is still connected to (receiving from)
+// the router.
+func (c *Client) Connected() bool { return c.ctx.Err() == nil }
 
 // ID returns the client's session ID which is assigned after attaching to a
 // router and joining a realm.
@@ -200,12 +200,9 @@ type EventHandler func(args wamp.List, kwargs, details wamp.Dict)
 //
 // NOTE: Use consts defined in wamp/options.go instead of raw strings.
 func (c *Client) Subscribe(topic string, fn EventHandler, options wamp.Dict) error {
-	c.sess.Lock()
-	if !c.connected {
-		c.sess.Unlock()
+	if !c.Connected() {
 		return ErrNotConn
 	}
-	c.sess.Unlock()
 
 	if options == nil {
 		options = wamp.Dict{}
@@ -263,12 +260,11 @@ func (c *Client) Unsubscribe(topic string) error {
 	// the topic, and may expect any.
 	delete(c.topicSubID, topic)
 	delete(c.eventHandlers, subID)
+	c.sess.Unlock()
 
-	if !c.connected {
-		c.sess.Unlock()
+	if !c.Connected() {
 		return ErrNotConn
 	}
-	c.sess.Unlock()
 
 	id := c.idGen.Next()
 	c.expectReply(id)
@@ -327,12 +323,9 @@ func (c *Client) Unsubscribe(topic string) error {
 //
 // NOTE: Use consts defined in wamp/options.go instead of raw strings.
 func (c *Client) Publish(topic string, options wamp.Dict, args wamp.List, kwargs wamp.Dict) error {
-	c.sess.Lock()
-	if !c.connected {
-		c.sess.Unlock()
+	if !c.Connected() {
 		return ErrNotConn
 	}
-	c.sess.Unlock()
 
 	if options == nil {
 		options = make(wamp.Dict)
@@ -401,13 +394,9 @@ type InvocationHandler func(context.Context, wamp.List, wamp.Dict, wamp.Dict) (r
 //
 // NOTE: Use consts defined in wamp/options.go instead of raw strings.
 func (c *Client) Register(procedure string, fn InvocationHandler, options wamp.Dict) error {
-	c.sess.Lock()
-	if !c.connected {
-		c.sess.Unlock()
+	if !c.Connected() {
 		return ErrNotConn
 	}
-	c.sess.Unlock()
-
 	id := c.idGen.Next()
 	c.expectReply(id)
 	if options == nil {
@@ -468,12 +457,11 @@ func (c *Client) Unregister(procedure string) error {
 	// for the procedure, and may not expect any.
 	delete(c.nameProcID, procedure)
 	delete(c.invHandlers, procID)
+	c.sess.Unlock()
 
-	if !c.connected {
-		c.sess.Unlock()
+	if !c.Connected() {
 		return ErrNotConn
 	}
-	c.sess.Unlock()
 
 	id := c.idGen.Next()
 	c.expectReply(id)
@@ -601,12 +589,9 @@ func (c *Client) CallProgress(ctx context.Context, procedure string, options wam
 			wamp.CancelModeKill, wamp.CancelModeKillNoWait, wamp.CancelModeSkip)
 	}
 
-	c.sess.Lock()
-	if !c.connected {
-		c.sess.Unlock()
+	if !c.Connected() {
 		return nil, ErrNotConn
 	}
-	c.sess.Unlock()
 
 	if options == nil {
 		options = wamp.Dict{}
@@ -684,39 +669,45 @@ func (rpce RPCError) Error() string {
 // Close causes the client to leave the realm it has joined, and closes the
 // connection to the router.
 func (c *Client) Close() error {
-	if !atomic.CompareAndSwapInt32(&c.closed, 0, 1) {
+	c.sess.Lock()
+	if c.closed {
+		c.sess.Unlock()
 		return ErrAlreadyClosed
 	}
-
-	// Cancel any running invocation handlers and wait for them to finish.  Do
-	// this before leaving the realm so that any invocation handlers do not
-	// hang waiting to send to the router after it has stopped receiving from
-	// the client.
-	close(c.stopping)
-	c.activeInvHandlers.Wait()
-
-	// Stop waiting for replies and clear the reply channel of pending writes.
-	var awaitingReply map[wamp.ID]chan wamp.Message
-	c.sess.Lock()
-	awaitingReply = c.awaitingReply
-	c.awaitingReply = nil
+	c.closed = true
 	c.sess.Unlock()
-	for _, ch := range awaitingReply {
-		select {
-		case <-ch:
-		default:
+
+	if c.Connected() {
+		// Leave the realm and stop receiving messages.
+
+		// Send GOODBYE to router.  The router will respond with a GOODBYE
+		// message which is handled by receiveFromRouter, and causes run() to
+		// exit.
+		//
+		// Make an effort to say goodbye, but do not wait around if blocked.
+		if c.sess.TrySend(&wamp.Goodbye{
+			Details: wamp.Dict{},
+			Reason:  wamp.CloseRealm,
+		}) == nil {
+			// Wait for run() to exit, but do not wait longer that a normal
+			// response timeout.
+			timer := time.NewTimer(c.responseTimeout)
+			select {
+			case <-c.Done():
+				timer.Stop()
+			case <-timer.C:
+				c.sess.EndRecv(nil) // force run() to exit
+				<-c.Done()
+			}
+		} else {
+			c.sess.EndRecv(nil) // force run() to exit
+			<-c.Done()
 		}
 	}
 
-	// Leave the realm and stop the client's main goroutine.
-	c.leaveRealm()
-
-	// The run goroutine is guaranteed to have exited when leaveRealm()
-	// returns, so there will be nothing trying to write to the reply channel.
-	// Closing the channels dismisses any possible readers.
-	for _, ch := range awaitingReply {
-		close(ch)
-	}
+	// When for any running invocation handlers to finish.
+	c.activeInvHandlers.Wait()
+	c.sess.Close()
 
 	return nil
 }
@@ -727,7 +718,7 @@ func (c *Client) Close() error {
 // calling this function.
 func (c *Client) RouterGoodbye() *wamp.Goodbye {
 	select {
-	case <-c.done:
+	case <-c.Done():
 	default:
 		// Client not disconnected from router yet.
 		return nil
@@ -741,16 +732,16 @@ func (c *Client) RouterGoodbye() *wamp.Goodbye {
 // that was passed into the invocation handler.  This context is responsible
 // for associating progressive results with the call in progress.
 func (c *Client) SendProgress(ctx context.Context, args wamp.List, kwArgs wamp.Dict) error {
+	if !c.Connected() {
+		return ErrNotConn
+	}
+
 	// Lookup the request ID using ctx.  If there is no request ID, this means
 	// that the caller is not accepting progressive results, or that the
 	// invocation handler has been closed because the call was canceled.
 	var req wamp.ID
 	var ok bool
 	c.sess.Lock()
-	if !c.connected {
-		c.sess.Unlock()
-		return ErrNotConn
-	}
 	req, ok = c.progGate[ctx]
 	c.sess.Unlock()
 
@@ -821,36 +812,6 @@ func joinRealm(peer wamp.Peer, cfg Config) (*wamp.Welcome, error) {
 		return nil, unexpectedMsgError(msg, wamp.WELCOME)
 	}
 	return welcome, nil
-}
-
-// leaveRealm leaves the current realm without closing the connection to the
-// router.
-func (c *Client) leaveRealm() {
-	select {
-	case <-c.done: // run already exited, client already disconnected
-		return
-	default:
-	}
-
-	// Send GOODBYE to router.  The router will respond with a GOODBYE message
-	// which is handled by receiveFromRouter, and causes run() to exit.
-	//
-	// Make an effort to say goodbye, but do not wait around if blocked.
-	c.sess.TrySend(&wamp.Goodbye{
-		Details: wamp.Dict{},
-		Reason:  wamp.CloseRealm,
-	})
-
-	// Wait for run() to exit, but do not wait longer that a normal response
-	// timeout.
-	timer := time.NewTimer(c.responseTimeout)
-	select {
-	case <-c.done:
-		timer.Stop()
-	case <-timer.C:
-		c.sess.EndRecv(nil) // force run() to exit
-		<-c.done
-	}
 }
 
 func handleCRAuth(peer wamp.Peer, challenge *wamp.Challenge, authHandlers map[string]AuthFunc, rspTimeout time.Duration) (wamp.Message, error) {
@@ -961,9 +922,7 @@ func unexpectedMsgError(msg wamp.Message, expected wamp.MessageType) error {
 func (c *Client) expectReply(id wamp.ID) {
 	wait := make(chan wamp.Message)
 	c.sess.Lock()
-	if c.awaitingReply != nil { // Client has already been closed
-		c.awaitingReply[id] = wait
-	}
+	c.awaitingReply[id] = wait
 	c.sess.Unlock()
 }
 
@@ -990,10 +949,12 @@ func (c *Client) waitForReply(id wamp.ID) (wamp.Message, error) {
 		timer.Stop()
 		if !ok {
 			// Return directly here, since awaitingReply entry already deleted.
-			return nil, ErrClosed
+			return nil, ErrNotConn
 		}
 	case <-timer.C:
 		err = ErrReplyTimeout
+	case <-c.Done():
+		err = ErrNotConn
 	}
 	c.sess.Lock()
 	delete(c.awaitingReply, id)
@@ -1028,7 +989,7 @@ CollectResults:
 	case msg, ok = <-wait:
 		if !ok {
 			// Return here, since awaitingReply entry already deleted.
-			return nil, ErrClosed
+			return nil, ErrNotConn
 		}
 		// If this is a progressive result, put the Result message on the
 		// progress channel and go back to waiting for more results.
@@ -1070,6 +1031,8 @@ CollectResults:
 			// Did not get expected response to cancel
 			err = ErrReplyTimeout
 		}
+	case <-c.Done():
+		err = ErrNotConn
 	}
 	// All done with this call, so not waiting for more replies.
 	c.sess.Lock()
@@ -1082,16 +1045,10 @@ CollectResults:
 // run is the core client goroutine.  This handles messages received from the
 // router and serializes access to all mutable state.
 func (c *Client) run() {
-	defer func() {
-		c.sess.Close() // close peer
-		close(c.done)  // signal client done
-		if c.debug {
-			c.log.Println("Client", c.sess, "closed")
-		}
-		c.sess.Lock()
-		c.connected = false
-		c.sess.Unlock()
-	}()
+	defer c.cancel()
+	if c.debug {
+		defer c.log.Println("Client", c.sess, "closed")
+	}
 
 	recv := c.sess.Recv()
 	recvDone := c.sess.RecvDone()
@@ -1256,7 +1213,7 @@ func (c *Client) runHandleInvocation(msg *wamp.Invocation) {
 				result = &InvokeResult{Err: wamp.ErrCanceled}
 				c.log.Println("INVOCATION", msg.Request, "canceled by callee")
 			}
-		case <-c.stopping:
+		case <-c.Done():
 			c.log.Print("Client stopping, invocation handler canceled")
 			// Return without sending response to server.  This will also
 			// cancel the context.
@@ -1275,7 +1232,7 @@ func (c *Client) runHandleInvocation(msg *wamp.Invocation) {
 		}
 
 		if result.Err != "" {
-			c.sess.Send(&wamp.Error{
+			c.sess.SendCtx(c.ctx, &wamp.Error{
 				Type:        wamp.INVOCATION,
 				Request:     msg.Request,
 				Details:     wamp.Dict{},
@@ -1285,7 +1242,7 @@ func (c *Client) runHandleInvocation(msg *wamp.Invocation) {
 			})
 			return
 		}
-		c.sess.Send(&wamp.Yield{
+		c.sess.SendCtx(c.ctx, &wamp.Yield{
 			Request:     msg.Request,
 			Options:     wamp.Dict{},
 			Arguments:   result.Args,
@@ -1324,5 +1281,8 @@ func (c *Client) runSignalReply(msg wamp.Message, requestID wamp.ID) {
 			"that client is no longer waiting for")
 		return
 	}
-	w <- msg
+	select {
+	case w <- msg:
+	case <-c.Done():
+	}
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -51,6 +51,7 @@ func connectedTestClients() (*Client, *Client, router.Router, error) {
 		AnonymousAuth:    true,
 		AllowDisclose:    true,
 		RequireLocalAuth: true,
+		EnableMetaKill:   true,
 	}
 	r, err := getTestRouter(realmConfig)
 	if err != nil {
@@ -723,7 +724,6 @@ func createTestServer() (router.Router, io.Closer, error) {
 
 func newNetTestCallee(routerURL string) (*Client, error) {
 	logger := log.New(os.Stderr, "CALLEE> ", log.Lmicroseconds)
-
 	cfg := Config{
 		Realm:           testRealm,
 		ResponseTimeout: 10 * time.Millisecond,
@@ -737,9 +737,9 @@ func newNetTestCallee(routerURL string) (*Client, error) {
 	}
 
 	sleep := func(ctx context.Context, args wamp.List, kwargs, details wamp.Dict) *InvokeResult {
-		log.Println("sleep rpc start")
+		logger.Println("sleep rpc start")
 		time.Sleep(5 * time.Second)
-		log.Println("sleep rpc done")
+		logger.Println("sleep rpc done")
 		return &InvokeResult{Kwargs: wamp.Dict{"success": true}}
 	}
 
@@ -810,7 +810,6 @@ func newNetTestKiller(routerURL string) (*Client, error) {
 
 // Test for races in client when session is killed by router.
 func TestClientRace(t *testing.T) {
-
 	// Create a websocket server
 	r, closer, err := createTestServer()
 	if err != nil {
@@ -896,4 +895,96 @@ func TestInvocationHandlerMissedDone(t *testing.T) {
 		t.Fatal("Timed out waiting to close client")
 	}
 	r.Close()
+}
+
+func TestProgressDisconnect(t *testing.T) {
+	defer leaktest.Check(t)()
+
+	// Create a websocket server
+	r, closer, err := createTestServer()
+	if err != nil {
+		t.Fatal("failed to connect test clients:", err)
+	}
+	//defer r.Close()
+	defer closer.Close()
+
+	testURL := fmt.Sprintf("ws://%s/ws", testAddress)
+
+	// Connect callee session.
+	calleeLog := log.New(os.Stderr, "CALLEE> ", log.Lmicroseconds)
+	cfg := Config{
+		Realm:           testRealm,
+		ResponseTimeout: 10 * time.Millisecond,
+		Logger:          calleeLog,
+		Debug:           true,
+	}
+	callee, err := ConnectNet(testURL, cfg)
+	if err != nil {
+		t.Fatalf("connect error: %s", err)
+	}
+	defer callee.Close()
+
+	const chunkProc = "example.progress.text"
+	sendProgErr := make(chan error)
+	disconnect := make(chan struct{})
+	disconnected := make(chan struct{})
+
+	// Define invocation handler.
+	handler := func(ctx context.Context, args wamp.List, kwargs, details wamp.Dict) *InvokeResult {
+		for {
+			// Send a chunk of data.
+			e := callee.SendProgress(ctx, wamp.List{"hello"}, nil)
+			if e != nil {
+				sendProgErr <- e
+				return nil
+			}
+			<-disconnected
+		}
+		// Never gets here
+	}
+
+	// Register procedure.
+	if err = callee.Register(chunkProc, handler, nil); err != nil {
+		t.Fatal("Failed to register procedure:", err)
+	}
+
+	// Connect caller session.
+	cfg.Logger = log.New(os.Stderr, "CALLER> ", log.Lmicroseconds)
+	caller, err := ConnectNet(testURL, cfg)
+	if err != nil {
+		t.Fatalf("connect error: %s", err)
+	}
+	defer caller.Close()
+
+	// The progress handler accumulates the chunks of data as they arrive.
+	progHandler := func(result *wamp.Result) {
+		close(disconnect)
+	}
+
+	// All results, for all calls, must be recieved by timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	progErr := make(chan error)
+	go func() {
+		_, perr := caller.CallProgress(ctx, chunkProc, nil, nil, nil, "", progHandler)
+		progErr <- perr
+	}()
+
+	<-disconnect
+	closer.Close()
+	r.Close()
+	close(disconnected)
+
+	// Check for expected error from caller.
+	err = <-progErr
+	if err != ErrNotConn {
+		t.Fatalf("expected error from caller: %q got %q", ErrNotConn, err)
+	}
+
+	// Check for expected error from callee.
+	err = <-sendProgErr
+	if err != context.Canceled && err != ErrNotConn {
+		t.Fatalf("wrong error from SendProgress: %s", err)
+	}
 }

--- a/client/error.go
+++ b/client/error.go
@@ -5,8 +5,7 @@ import "errors"
 var (
 	ErrAlreadyClosed = errors.New("already closed")
 	ErrCallerNoProg  = errors.New("caller not accepting progressive results")
-	ErrClosed        = errors.New("client closed")
-	ErrNotConn       = errors.New("client not connected")
+	ErrNotConn       = errors.New("not connected")
 	ErrNotRegistered = errors.New("not registered for procedure")
 	ErrNotSubscribed = errors.New("not subscribed to topic")
 	ErrReplyTimeout  = errors.New("timeout waiting for reply")

--- a/client/error.go
+++ b/client/error.go
@@ -1,0 +1,14 @@
+package client
+
+import "errors"
+
+var (
+	ErrAlreadyClosed = errors.New("already closed")
+	ErrCallerNoProg  = errors.New("caller not accepting progressive results")
+	ErrClosed        = errors.New("client closed")
+	ErrNotConn       = errors.New("client not connected")
+	ErrNotRegistered = errors.New("not registered for procedure")
+	ErrNotSubscribed = errors.New("not subscribed to topic")
+	ErrReplyTimeout  = errors.New("timeout waiting for reply")
+	ErrRouterNoRoles = errors.New("router did not announce any supported roles")
+)

--- a/examples/pubsub/publisher/publisher.go
+++ b/examples/pubsub/publisher/publisher.go
@@ -23,14 +23,14 @@ func main() {
 	args := wamp.List{"hello world"}
 	err = publisher.Publish(exampleTopic, nil, args, nil)
 	if err != nil {
-		logger.Fatal("subscribe error:", err)
+		logger.Fatalf("publish error: %s", err)
 	}
 
 	// Publish more events to topic.
 	args = wamp.List{"how are you today"}
 	err = publisher.Publish(exampleTopic, nil, args, nil)
 	if err != nil {
-		logger.Fatal("subscribe error:", err)
+		logger.Fatalf("publish error: %s", err)
 	}
 
 	// Publish events only to sessions 42, 1138, 1701.
@@ -38,26 +38,27 @@ func main() {
 	opts := wamp.Dict{wamp.WhitelistKey: wamp.List{42, 1138, 1701}}
 	err = publisher.Publish(exampleTopic, opts, args, nil)
 	if err != nil {
-		logger.Fatal("subscribe error:", err)
+		logger.Fatalf("publish error: %s", err)
 	}
 
 	args = wamp.List{"testing 1"}
 	err = publisher.Publish(exampleTopic, nil, args, nil)
 	if err != nil {
-		logger.Fatal("subscribe error:", err)
+		logger.Fatalf("publish error: %s", err)
 	}
 
 	args = wamp.List{"testing 2"}
 	err = publisher.Publish(exampleTopic, nil, args, nil)
 	if err != nil {
-		logger.Fatal("subscribe error:", err)
+		logger.Fatalf("publish error: %s", err)
 	}
 
 	args = wamp.List{"testing 3"}
 	err = publisher.Publish(exampleTopic, nil, args, nil)
 	if err != nil {
-		logger.Fatal("subscribe error:", err)
+		logger.Fatalf("publish error: %s", err)
 	}
 
 	logger.Println("Published messages to", exampleTopic)
+	publisher.Close()
 }

--- a/router/realm.go
+++ b/router/realm.go
@@ -476,16 +476,18 @@ func (r *realm) handleInboundMessages(sess *wamp.Session) (bool, bool, error) {
 	if r.debug {
 		defer r.log.Println("Ended session", sess)
 	}
+	recv := sess.Recv()
+	recvDone := sess.RecvDone()
 	for {
 		var msg wamp.Message
 		var open bool
 		select {
-		case msg, open = <-sess.Recv():
+		case msg, open = <-recv:
 			if !open {
 				r.log.Println("Lost", sess)
 				return false, false, nil
 			}
-		case <-sess.RecvDone():
+		case <-recvDone:
 			goodbye := sess.Goodbye()
 			switch goodbye {
 			case shutdownGoodbye, wamp.NoGoodbye:


### PR DESCRIPTION
Fixes issue #194

Client check that the connection to the router is ok before sending a message to the router.  This avoids repeatedly sending a message, that does not expect a reply, without detecting the loss of the connection to the router.

- Check router connection before sending
- Client returns specific error values for most errors