### PR TITLE
Feature/add debug print

### DIFF
--- a/client/network.go
+++ b/client/network.go
@@ -56,7 +56,7 @@ func ConnectNetContext(ctx context.Context, routerURL string, cfg Config) (*Clie
 		routerURL = u.String()
 		fallthrough
 	case "ws", "wss":
-		p, err = transport.ConnectWebsocketPeerContext(ctx, routerURL, cfg.Serialization,
+		p, _, err = transport.ConnectWebsocketPeerContext(ctx, routerURL, cfg.Serialization,
 			cfg.TlsCfg, cfg.Dial, cfg.Logger, &cfg.WsCfg)
 	case "tcp":
 		p, err = transport.ConnectRawSocketPeerContext(ctx, u.Scheme, u.Host,

--- a/router/websocketserver_test.go
+++ b/router/websocketserver_test.go
@@ -48,7 +48,7 @@ func TestWSHandshakeJSON(t *testing.T) {
 	wsCfg := transport.WebsocketConfig{
 		EnableCompression: true,
 	}
-	client, err := transport.ConnectWebsocketPeer(
+	client, _, err := transport.ConnectWebsocketPeer(
 		fmt.Sprintf("ws://%s/", wsAddr), serialize.JSON, nil, nil, r.Logger(), &wsCfg)
 	if err != nil {
 		t.Fatal(err)
@@ -81,7 +81,7 @@ func TestWSHandshakeMsgpack(t *testing.T) {
 	}
 	defer closer.Close()
 
-	client, err := transport.ConnectWebsocketPeer(
+	client, _, err := transport.ConnectWebsocketPeer(
 		fmt.Sprintf("ws://%s/", wsAddr), serialize.MSGPACK, nil, nil, r.Logger(), nil)
 	if err != nil {
 		t.Fatal(err)

--- a/transport/websocketpeer.go
+++ b/transport/websocketpeer.go
@@ -93,6 +93,7 @@ func ConnectWebsocketPeer(
 func ConnectWebsocketPeerContext(ctx context.Context, routerURL string, serialization serialize.Serialization, tlsConfig *tls.Config, dial DialFunc, logger stdlog.StdLog, wsCfg *WebsocketConfig) (wamp.Peer, error) {
 	var (
 		protocol    string
+		res         *http.Response
 		payloadType int
 		serializer  serialize.Serializer
 		conn        *websocket.Conn
@@ -136,8 +137,11 @@ func ConnectWebsocketPeerContext(ctx context.Context, routerURL string, serializ
 		dialer.EnableCompression = true
 	}
 
-	conn, _, err = dialer.DialContext(ctx, routerURL, nil)
+	conn, res, err = dialer.DialContext(ctx, routerURL, nil)
 	if err != nil {
+		if res != nil {
+			fmt.Println("Response from server: ", res)
+		}
 		return nil, err
 	}
 	return NewWebsocketPeer(conn, serializer, payloadType, logger, 0, 0), nil


### PR DESCRIPTION
DialContext is capable of returning a non nil response after returning an error, this response is critical for debugging connection errors.

A complete example of this is when an ErrBadHandshake is returned. The error string simply shows "websocket: bad handshake", without access to the response struct this is very difficult to debug. This PR returns the response so it can be printed by the caller