### PR TITLE
apply filter only if argument is not nil

### DIFF
--- a/router/realm.go
+++ b/router/realm.go
@@ -791,7 +791,7 @@ func (r *realm) sessionCount(msg *wamp.Invocation) wamp.Message {
 // IDs for all sessions currently attached to the realm.
 func (r *realm) sessionList(msg *wamp.Invocation) wamp.Message {
 	var filter []string
-	if len(msg.Arguments) != 0 {
+	if len(msg.Arguments) != 0 && msg.Arguments[0] != nil {
 		filterList, ok := wamp.AsList(msg.Arguments[0])
 		if !ok {
 			return &wamp.Error{

--- a/router/realm_test.go
+++ b/router/realm_test.go
@@ -1,0 +1,19 @@
+package router
+
+import (
+	"github.com/gammazero/nexus/v3/wamp"
+	"testing"
+)
+
+func TestRealm_sessionList(t *testing.T) {
+	realm := new(realm)
+	invocation := wamp.Invocation{
+		Arguments: make(wamp.List, 1),
+	}
+
+	response := realm.sessionList(&invocation)
+	errorMessage, ok := response.(*wamp.Error)
+	if ok {
+		t.Fatal("Response contains error", errorMessage)
+	}
+}


### PR DESCRIPTION
Bugfix in implementation for wamp.session.list
Optional filter argument is present but nil on requests received from autobahn python client.