### PR TITLE
[NFR] Allow custom connections to be specified in transport.NewWebsocketPeer()

### DIFF
--- a/router/websocketserver.go
+++ b/router/websocketserver.go
@@ -344,7 +344,7 @@ func (s *WebsocketServer) addProtocol(proto string, payloadType int, serializer 
 	return nil
 }
 
-func (s *WebsocketServer) handleWebsocket(conn *websocket.Conn, transportDetails wamp.Dict) {
+func (s *WebsocketServer) handleWebsocket(conn transport.WebsocketConnection, transportDetails wamp.Dict) {
 	var serializer serialize.Serializer
 	var payloadType int
 	// Get serializer and payload type for protocol.

--- a/transport/websocketpeer.go
+++ b/transport/websocketpeer.go
@@ -39,8 +39,7 @@ type WebsocketConfig struct {
 	ProxyURL string
 }
 
-// WebsocketConnection is a closable connection which reads and writes raw
-// message data, handles pong requests and has a subprotocol
+// WebsocketConnection is the interface that a websocket connection must implement.
 type WebsocketConnection interface {
 	Close() error
 	WriteControl(messageType int, data []byte, deadline time.Time) error


### PR DESCRIPTION
It would be nice to be able to run your client library embedded in a WASM binary.
The problem is that TCP connections are not supported, so the https://github.com/gorilla/websocket implementation is a no-go...

This PR would allow for custom connections to be specified in ```transport.NewWebsocketPeer```, like a wrapper around ```window.WebSocket``` using the js runtime.