### PR TITLE
Cancel any pending invocations for a callee that is leaving

### DIFF
--- a/router/dealer.go
+++ b/router/dealer.go
@@ -1023,6 +1023,8 @@ func (d *dealer) syncRemoveSession(sess *wamp.Session) []*wamp.Publish {
 		if errArgs == nil {
 			errArgs = wamp.List{"callee gone"}
 		}
+		// Use CancelModeSkip so as not to send an INTERRUPT to a callee that
+		// is no longer there.
 		d.syncCancel(caller, &wamp.Cancel{Request: invk.callID.request},
 			wamp.CancelModeSkip, wamp.ErrCanceled, errArgs)
 


### PR DESCRIPTION
When a callee has been called, but has not yet returned a response and disconnects before a response is returned, then pending calls will hang until the caller decides to cancel them.  This fixes that by canceling any pending calls to a callee that disconnects.