### PR TITLE
Add nexus client to demonstrate interoperability with autobahn client.

### DIFF
--- a/examples/interop/autobahn-python/README.md
+++ b/examples/interop/autobahn-python/README.md
@@ -1,10 +1,11 @@
 # Autobahn Python Client Examples
 
-The Autobahn python client examples demonstrate basic WAMP functionality when running a non-nexus client against a nexus router.
+The Autobahn python client examples demonstrate basic WAMP functionality when running a non-nexus client against a nexus router.  A nexus client is included to demonstrate interoperability when publishing events, and rpc with and withouth progressive results.
 
-To run the Autobahn Python examples:
+To run the Autobahn Python with nexus examples:
 
 1. Setup the python/autobahn environment.  Running `make` should do that.
-2. Run a nexus server from the examples.
+2. Run a nexus server from the examples. `cd examples/server; go run server.go`
 3. Run the subscriber-callee: `./pyenv/bin/python sub_callee.py`
-4. Run the publisher-caller: `./pyenv/bin/python pub_caller.py`
+4. Run the autobahn publisher-caller: `./pyenv/bin/python pub_caller.py`
+5. Run the nexus publisher-caller: `go run pub_caller.go`

--- a/examples/interop/autobahn-python/pub_caller.go
+++ b/examples/interop/autobahn-python/pub_caller.go
@@ -1,0 +1,90 @@
+/*
+Go WAMP client: publisher and caller
+
+Publishes events and makes RPC calls to the python-autobahn client in this
+directory to demonstrate interoperability.
+
+*/
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/gammazero/nexus/v3/client"
+	"github.com/gammazero/nexus/v3/wamp"
+)
+
+const (
+	addr  = "ws://localhost:8000/ws"
+	realm = "realm1"
+
+	topic = "example.hello"
+
+	procedure  = "example.add2"
+	procedure2 = "example.longop"
+)
+
+func main() {
+	cfg := client.Config{
+		Realm:  realm,
+		Logger: log.New(os.Stderr, "go-client> ", 0),
+	}
+	cli, err := client.ConnectNet(context.Background(), addr, cfg)
+	if err != nil {
+		fmt.Println("connot connect to router", err)
+		return
+	}
+	defer cli.Close()
+
+	publishEvents(cli)
+	callRpc(cli)
+	callRpcProgressiveResults(cli)
+}
+
+func publishEvents(publisher *client.Client) {
+	// Publish events to topic
+	for i := 0; i < 5; i++ {
+		msg := fmt.Sprintf("Testing %d", i)
+		err := publisher.Publish(topic, nil, wamp.List{msg}, nil)
+		if err != nil {
+			fmt.Printf("publish error: %s", err)
+			return
+		}
+		fmt.Printf("Published %q\n", msg)
+		time.Sleep(time.Second)
+	}
+}
+
+func callRpc(caller *client.Client) {
+	// Call procedure to sum arguments
+	ctx := context.Background()
+	result, err := caller.Call(ctx, procedure, nil, wamp.List{2, 3}, nil, nil)
+	if err != nil {
+		fmt.Println("Failed to call procedure:", err)
+		return
+	}
+	val, _ := wamp.AsInt64(result.Arguments[0])
+	fmt.Println("Call result:", val)
+}
+
+func callRpcProgressiveResults(caller *client.Client) {
+	progHandler := func(result *wamp.Result) {
+		progResult := result.Arguments[0].(string)
+		fmt.Println("Received chunk:", progResult)
+	}
+
+	// Call procedure to get progressive results
+	ctx := context.Background()
+	result, err := caller.Call(
+		ctx, procedure2, nil, wamp.List{"a"}, nil, progHandler)
+	if err != nil {
+		fmt.Println("Failed to call procedure:", err)
+		return
+	}
+
+	fmt.Println("Final result:", result.Arguments[0].(string))
+}

--- a/examples/interop/autobahn-python/pub_caller.py
+++ b/examples/interop/autobahn-python/pub_caller.py
@@ -1,5 +1,5 @@
 #
-# Python WAMP client: publisher
+# Python WAMP client: publisher and caller
 #
 # Install dependencies:
 #     https://github.com/crossbario/autobahn-python/wiki/Autobahn-on-Ubuntu

--- a/examples/server/server.go
+++ b/examples/server/server.go
@@ -103,6 +103,7 @@ func main() {
 	log.Printf("RawSocket TCP server listening on tcp://%s/", tcpAddr)
 
 	// Run unix rawsocket server.
+	os.Remove(unixAddr)
 	unixCloser, err := rss.ListenAndServe("unix", unixAddr)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This addresses issue #208. It demonstrates a nexus client working with an autobahn python client to do:
- event publishing
- rpc
- rpc with progressive results 
