### PR TITLE
Do not decode msgpack raw bytes as string

### DIFF
--- a/examples/interop/autobahn-nodejs/caller.ts
+++ b/examples/interop/autobahn-nodejs/caller.ts
@@ -3,7 +3,7 @@ import {AuthobanClient} from "./client"
 
 function main() {
 
-    let arithmeticServer = new AuthobanClient({realm:"nexus.examples",port:8000})
+    let arithmeticServer = new AuthobanClient({realm:"nexus.examples",port:8080})
 
     let arrayToSum = [1,2,3,4,5]
 

--- a/examples/interop/autobahn-nodejs/client.ts
+++ b/examples/interop/autobahn-nodejs/client.ts
@@ -5,7 +5,7 @@ export class AuthobanClient {
     connectP: Promise<any>;
     connection: Connection;
 
-    constructor(private options: { debug?: boolean, port?:number, realm?:string } = { debug: false, port: 8008 }) {
+    constructor(private options: { debug?: boolean, port?:number, realm?:string } = { debug: false, port: 8080 }) {
     }
 
     connect(): Promise<any> {

--- a/examples/interop/autobahn-python/Makefile
+++ b/examples/interop/autobahn-python/Makefile
@@ -5,21 +5,27 @@ PIP3 = $(PYENV)/bin/pip3
 
 all: autobahn
 
+# Install autobahn dependencies into venv
+# See: https://github.com/crossbario/autobahn-python/wiki/Autobahn-on-Ubuntu
 autobahn: $(PIP3)
-	$(PIP3) install autobahn[twisted] > /dev/null
+	$(PIP3) install autobahn[twisted,asyncio,serialization] > /dev/null
 	@echo "===> installed autobahn"
 
+# Install pip into venv
 $(PIP3): $(PYENV) get-pip.py
 	$(PYENV)/bin/python3 get-pip.py > /dev/null
 	@echo "===> installed pip into venv"
 
+# Create python venv
 $(PYENV):
 	python3 -m venv --without-pip $(PYENV)
 	@echo "===> created venv $@"
 
+# Get pip installer
 get-pip.py:
 	wget -N https://bootstrap.pypa.io/get-pip.py
 
+# Remove venv and pip installer
 clean:
 	@rm -rf $(PYENV)
 	@rm -f get-pip.py

--- a/examples/interop/autobahn-python/README.md
+++ b/examples/interop/autobahn-python/README.md
@@ -5,7 +5,9 @@ The Autobahn python client examples demonstrate basic WAMP functionality when ru
 To run the Autobahn Python with nexus examples:
 
 1. Setup the python/autobahn environment.  Running `make` should do that.
-2. Run a nexus server from the examples. `cd examples/server; go run server.go`
+2. Run a nexus server from examples, `cd examples/server; go run server.go` or run nexusd, `cd nexusd; make; ./nexusd`
 3. Run the subscriber-callee: `./pyenv/bin/python sub_callee.py`
 4. Run the autobahn publisher-caller: `./pyenv/bin/python pub_caller.py`
 5. Run the nexus publisher-caller: `go run pub_caller.go`
+6. Run the echo callee: `./pyenv/bin/python echo_callee.py`
+7. Run the echo caller: `./pyenv/bin/python echo_caller.py`

--- a/examples/interop/autobahn-python/echo_callee.py
+++ b/examples/interop/autobahn-python/echo_callee.py
@@ -1,0 +1,47 @@
+#
+# Python WAMP client: callee that handles RPC from echo_caller.py
+#
+# Install dependencies:
+#     make
+#
+# Run this client:
+#    ./pyenv/bin/python echo_callee.py
+#
+import asyncio
+from autobahn.asyncio.wamp import ApplicationSession
+from autobahn.asyncio.component import Component, run
+
+
+class Backend(ApplicationSession):
+    def __init__(self, config=None):
+        config.realm = "realm1"
+        super().__init__(config)
+
+    async def onJoin(self, details):
+        print('Register test_echo_payload')
+        await self.register(self.test_echo_payload, 'test.echo.payload')
+
+    async def onDisconnect(self):
+        loop  = asyncio.get_event_loop()
+        loop.stop()
+
+    async def test_echo_payload(self, value: bytes) -> bytes:
+        if not isinstance(value, bytes):
+            print('Value is not an instance of bytes but is a %s' % (type(value)))
+        return value
+
+
+if __name__ == '__main__':
+    backend = Component(
+            session_factory = Backend,
+            transports      = [
+                {
+                    'type':        'websocket',
+                    'serializers': ['msgpack'],
+                    'url':         'ws://localhost:8080/ws',
+                    'max_retries': 3
+                }
+            ]
+        )
+
+    run([backend])

--- a/examples/interop/autobahn-python/echo_caller.py
+++ b/examples/interop/autobahn-python/echo_caller.py
@@ -1,0 +1,48 @@
+#
+# Python WAMP client: caller that calls RPC registered by echo_callee.py
+#
+# Install dependencies:
+#     make
+#
+# Run this client:
+#    ./pyenv/bin/python echo_caller.py
+#
+import asyncio
+from autobahn.asyncio.wamp import ApplicationSession
+from autobahn.asyncio.component import Component, run
+
+
+class Client(ApplicationSession):
+    def __init__(self, config=None):
+        config.realm = "realm1"
+        super().__init__(config)
+
+    async def onJoin(self, details):
+        print('Call test_echo_payload')
+        loop = asyncio.get_running_loop()
+        loop.create_task(self.test_echo_payload())
+
+    async def onDisconnect(self):
+        loop  = asyncio.get_event_loop()
+        loop.stop()
+
+    async def test_echo_payload(self):
+        message_bytes = b'\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10'
+        ret = await self.call('test.echo.payload', message_bytes)
+        print("Received response:", ret)
+
+
+if __name__ == '__main__':
+    client = Component(
+            session_factory = Client,
+            transports      = [
+                {
+                    'type':        'websocket',
+                    'serializers': ['msgpack'],
+                    'url':         'ws://localhost:8080/ws',
+                    'max_retries': 3
+                }
+            ]
+        )
+
+    run([client])

--- a/examples/interop/autobahn-python/pub_caller.go
+++ b/examples/interop/autobahn-python/pub_caller.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	addr  = "ws://localhost:8000/ws"
+	addr  = "ws://localhost:8080/ws"
 	realm = "realm1"
 
 	topic = "example.hello"
@@ -30,8 +30,9 @@ const (
 
 func main() {
 	cfg := client.Config{
-		Realm:  realm,
-		Logger: log.New(os.Stderr, "go-client> ", 0),
+		Realm:         realm,
+		Logger:        log.New(os.Stderr, "go-client> ", 0),
+		Serialization: client.MSGPACK,
 	}
 	cli, err := client.ConnectNet(context.Background(), addr, cfg)
 	if err != nil {

--- a/examples/interop/autobahn-python/pub_caller.py
+++ b/examples/interop/autobahn-python/pub_caller.py
@@ -2,10 +2,10 @@
 # Python WAMP client: publisher and caller
 #
 # Install dependencies:
-#     https://github.com/crossbario/autobahn-python/wiki/Autobahn-on-Ubuntu
+#     make
 #
 # Run this client:
-#    ./pyenv1/bin/python pub_caller.py
+#    ./pyenv/bin/python pub_caller.py
 #
 from __future__ import print_function
 from twisted.internet.defer import inlineCallbacks
@@ -43,7 +43,6 @@ class MyComponent(ApplicationSession):
 
 
         def on_prog(msg):
-            print("here")
             print("partial result: {}".format(msg))
 
         print('Calling procedure:', procedure2)
@@ -56,5 +55,5 @@ class MyComponent(ApplicationSession):
 
 
 if __name__ == '__main__':
-    runner = ApplicationRunner(url=u"ws://localhost:8000/ws", realm=realm)
+    runner = ApplicationRunner(url=u"ws://localhost:8080/ws", realm=realm)
     runner.run(MyComponent)

--- a/examples/interop/autobahn-python/sub_callee.py
+++ b/examples/interop/autobahn-python/sub_callee.py
@@ -1,11 +1,11 @@
 #
-# Python WAMP client: subscriber
+# Python WAMP client: subscriber and callee
 #
 # Install dependencies:
-#     https://github.com/crossbario/autobahn-python/wiki/Autobahn-on-Ubuntu
+#     make
 #
 # Run this client:
-#    ./pyenv1/bin/python sub_callee.py
+#    ./pyenv/bin/python sub_callee.py
 #
 from __future__ import print_function
 from twisted.internet.defer import inlineCallbacks, returnValue
@@ -72,6 +72,6 @@ class MyComponent(ApplicationSession):
 
 
 if __name__ == '__main__':
-    runner = ApplicationRunner(url=u"ws://localhost:8000/ws", realm=realm)
+    runner = ApplicationRunner(url=u"ws://localhost:8080/ws", realm=realm)
     runner.run(MyComponent)
     print("Received", event_count, "events")

--- a/examples/interop/wampy-nodejs/caller.ts
+++ b/examples/interop/wampy-nodejs/caller.ts
@@ -3,7 +3,7 @@ import {WampClient} from "./client"
 
 function main() {
 
-    let sumServer = new WampClient({realm:"nexus.examples",port:8000})
+    let sumServer = new WampClient({realm:"nexus.examples",port:8080})
 
     let arrayToSum = [1,2,3,4,5]
 

--- a/examples/interop/wampy-nodejs/client.ts
+++ b/examples/interop/wampy-nodejs/client.ts
@@ -4,7 +4,7 @@ export class WampClient {
     connectP: Promise<any>;
     ws: any;
 
-    constructor(private options: { debug?: boolean, port?:number, realm?:string } = { debug: false, port: 8008 }) {
+    constructor(private options: { debug?: boolean, port?:number, realm?:string } = { debug: false, port: 8080 }) {
     }
 
     connect(): Promise<any> {

--- a/examples/newclient/newclient.go
+++ b/examples/newclient/newclient.go
@@ -25,10 +25,10 @@ const (
 	defaultAddr  = "localhost"
 	defaultUnix  = "/tmp/exmpl_nexus_sock"
 
-	defaultWsPort   = 8000
+	defaultWsPort   = 8080
 	defaultWssPort  = 8443
-	defaultTcpPort  = 8080
-	defaultTcpsPort = 8081
+	defaultTcpPort  = 8000
+	defaultTcpsPort = 8001
 )
 
 func NewClient(logger *log.Logger) (*client.Client, error) {

--- a/examples/server/server.go
+++ b/examples/server/server.go
@@ -32,10 +32,10 @@ func main() {
 		netAddr  = "localhost"
 		unixAddr = "/tmp/exmpl_nexus_sock"
 
-		wsPort   = 8000
+		wsPort   = 8080
 		wssPort  = 8443
-		tcpPort  = 8080
-		tcpsPort = 8081
+		tcpPort  = 8000
+		tcpsPort = 8001
 	)
 	flag.StringVar(&netAddr, "netaddr", netAddr, "network address to listen on")
 	flag.StringVar(&unixAddr, "unixaddr", unixAddr, "unix address to listen on")

--- a/examples/simple/server.go
+++ b/examples/simple/server.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	address = "localhost:8000"
+	address = "localhost:8080"
 	realm   = "realm1"
 )
 

--- a/nexusd/Makefile
+++ b/nexusd/Makefile
@@ -4,8 +4,9 @@ VERSION = $(shell git describe --tags)
 
 all: nexusd
 
-nexusd:
+nexusd: ../wamp/*.go ../wamp/crsign/*.go ../router/*.go ../router/auth/*.go ../transport/*.go ../transport/serialize/*.go ./*.go
 	@go build -ldflags="-X 'github.com/gammazero/nexus/v3/router.Version=${VERSION}'"
+	@echo "===> built $@"
 
 clean:
 	@rm -f nexusd

--- a/router/realm.go
+++ b/router/realm.go
@@ -398,7 +398,7 @@ func (r *realm) handleSession(sess *wamp.Session) error {
 	r.closeLock.Unlock()
 
 	if r.debug {
-		r.log.Println("Started session", sess)
+		r.log.Println("Handling messages for session", sess)
 	}
 	go func() {
 		shutdown, killAll, err := r.handleInboundMessages(sess)

--- a/transport/serialize/msgpackserializer.go
+++ b/transport/serialize/msgpackserializer.go
@@ -12,7 +12,6 @@ var mh *codec.MsgpackHandle
 
 func init() {
 	mh = new(codec.MsgpackHandle)
-	mh.RawToString = true
 	mh.WriteExt = true
 	mh.MapType = reflect.TypeOf(map[string]interface{}(nil))
 }

--- a/transport/websocketpeer.go
+++ b/transport/websocketpeer.go
@@ -257,7 +257,7 @@ sendLoop:
 	for {
 		select {
 		case msg := <-w.wr:
-			b, err := w.serializer.Serialize(msg.(wamp.Message))
+			b, err := w.serializer.Serialize(msg)
 			if err != nil {
 				w.log.Print(err)
 				continue sendLoop
@@ -295,7 +295,7 @@ recvLoop:
 	for {
 		select {
 		case msg := <-w.wr:
-			b, err := w.serializer.Serialize(msg.(wamp.Message))
+			b, err := w.serializer.Serialize(msg)
 			if err != nil {
 				w.log.Print(err)
 				continue recvLoop


### PR DESCRIPTION
When the router decodes a msgpack message that contains raw bytes, the router was decoding the bytes into a string.  When this data was then send out to destination client it was then encoded as a string and no longer as bytes.  This caused clients expecting bytes to get a string unexpectedly.

This is fixed by using the new msgpack spec and disabling the option to convert raw bytes to string.

This fixes issue #214