### PR TITLE
Fix/local client modifies msg

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1135,8 +1135,6 @@ func TestEventContentSafety(t *testing.T) {
 	errChan := make(chan error)
 	gate := make(chan struct{}, 1)
 	eventHandler := func(event *wamp.Event) {
-		fmt.Println("before")
-		defer fmt.Println("after")
 		gate <- struct{}{}
 		_, ok := event.Details["oops"]
 		if ok {
@@ -1155,6 +1153,7 @@ func TestEventContentSafety(t *testing.T) {
 			<-gate
 			return
 		}
+
 		event.Details["oops"] = true
 		event.Arguments[0] = "oops"
 		errChan <- nil

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1043,6 +1043,9 @@ func (*testEmptyDictLeakAuthorizer) Authorize(sess *wamp.Session, message wamp.M
 		subMsg *wamp.Subscribe
 		ok     bool
 	)
+	if _, ok = message.(*wamp.Goodbye); ok {
+		return true, nil
+	}
 	if subMsg, ok = message.(*wamp.Subscribe); !ok {
 		panic(fmt.Sprintf("I can only handle %T, saw %T", subMsg, message))
 	}
@@ -1110,4 +1113,74 @@ func TestEmptyDictLeak(t *testing.T) {
 	client2.Close()
 	router1.Close()
 	router2.Close()
+}
+
+func TestEventContentSafety(t *testing.T) {
+	defer leaktest.Check(t)()
+
+	// Connect two subscribers and one publisher to router
+	sub1, sub2, r, err := connectedTestClients()
+	if err != nil {
+		t.Fatal("failed to connect subscribers clients:", err)
+	}
+	defer sub1.Close()
+	defer sub2.Close()
+	defer r.Close()
+	pub, err := newTestClient(r)
+	if err != nil {
+		t.Fatal("failed to connect published client:", err)
+	}
+	defer pub.Close()
+
+	errChan := make(chan error)
+	gate := make(chan struct{}, 1)
+	eventHandler := func(event *wamp.Event) {
+		fmt.Println("before")
+		defer fmt.Println("after")
+		gate <- struct{}{}
+		_, ok := event.Details["oops"]
+		if ok {
+			errChan <- errors.New("should not have seen oops")
+			<-gate
+			return
+		}
+		arg, ok := event.Arguments[0].(string)
+		if !ok {
+			errChan <- errors.New("arg was not strings")
+			<-gate
+			return
+		}
+		if arg != "Hello" {
+			errChan <- fmt.Errorf("expected \"Hello\", got %q", arg)
+			<-gate
+			return
+		}
+		event.Details["oops"] = true
+		event.Arguments[0] = "oops"
+		errChan <- nil
+		<-gate
+	}
+
+	// Expect invalid URI error if not setting match option.
+	if err = sub1.Subscribe(testTopic, eventHandler, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err = sub2.Subscribe(testTopic, eventHandler, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = pub.Publish(testTopic, nil, wamp.List{"Hello"}, nil); err != nil {
+		t.Fatal("Failed to publish:", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		select {
+		case err = <-errChan:
+			if err != nil {
+				t.Fatal(err)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatal("did not get published event")
+		}
+	}
 }

--- a/router/broker_test.go
+++ b/router/broker_test.go
@@ -34,6 +34,8 @@ func (p *testPeer) SendCtx(ctx context.Context, msg wamp.Message) error {
 func (p *testPeer) Recv() <-chan wamp.Message { return p.in }
 func (p *testPeer) Close()                    { return }
 
+func (p *testPeer) IsLocal() bool { return true }
+
 func TestBasicSubscribe(t *testing.T) {
 	// Test subscribing to a topic.
 	broker := newBroker(logger, false, true, debug, nil)

--- a/router/realm.go
+++ b/router/realm.go
@@ -518,7 +518,7 @@ func (r *realm) handleInboundMessages(sess *wamp.Session) (bool, bool, error) {
 func (r *realm) authzMessage(sess *wamp.Session, msg wamp.Message) bool {
 	// If the client is local, then do not check authorization, unless
 	// requested in config.
-	if transport.IsLocal(sess.Peer) && !r.localAuthz {
+	if sess.Peer.IsLocal() && !r.localAuthz {
 		return true
 	}
 
@@ -587,7 +587,7 @@ func (r *realm) authzMessage(sess *wamp.Session, msg wamp.Message) bool {
 // HELLO message details and the authenticators available for this realm.
 func (r *realm) authClient(sid wamp.ID, client wamp.Peer, details wamp.Dict) (*wamp.Welcome, error) {
 	// If the client is local, then no authentication is required.
-	if transport.IsLocal(client) && !r.localAuth {
+	if client.IsLocal() && !r.localAuth {
 		// Create welcome details for local client.
 		authid, _ := wamp.AsString(details["authid"])
 		if authid == "" {

--- a/router/realm.go
+++ b/router/realm.go
@@ -73,11 +73,9 @@ type realm struct {
 }
 
 var (
-	emptyDict = wamp.Dict{}
-
 	shutdownGoodbye = &wamp.Goodbye{
 		Reason:  wamp.ErrSystemShutdown,
-		Details: emptyDict,
+		Details: wamp.Dict{},
 	}
 )
 
@@ -499,7 +497,7 @@ func (r *realm) handleInboundMessages(sess *wamp.Session) (bool, bool, error) {
 			// Handle client leaving realm.
 			sess.TrySend(&wamp.Goodbye{
 				Reason:  wamp.ErrGoodbyeAndOut,
-				Details: emptyDict,
+				Details: wamp.Dict{},
 			})
 			if r.debug {
 				r.log.Println("GOODBYE from session", sess, "reason:",
@@ -538,7 +536,7 @@ func (r *realm) authzMessage(sess *wamp.Session, msg wamp.Message) bool {
 
 	if !isAuthz {
 		skipResponse := false
-		errRsp := &wamp.Error{Type: msg.MessageType(), Details: emptyDict}
+		errRsp := &wamp.Error{Type: msg.MessageType(), Details: wamp.Dict{}}
 		// Get the Request from request types of messages.
 		switch msg := msg.(type) {
 		case *wamp.Publish:
@@ -719,7 +717,7 @@ func (r *realm) metaProcedureHandler() {
 				r.metaPeer.Send(&wamp.Error{
 					Type:    msg.MessageType(),
 					Request: msg.Request,
-					Details: emptyDict,
+					Details: wamp.Dict{},
 					Error:   wamp.ErrNoSuchProcedure,
 				})
 				continue
@@ -748,7 +746,7 @@ func (r *realm) sessionCount(msg *wamp.Invocation) wamp.Message {
 				Type:    wamp.INVOCATION,
 				Error:   wamp.ErrInvalidArgument,
 				Request: msg.Request,
-				Details: emptyDict,
+				Details: wamp.Dict{},
 			}
 		}
 		filter, ok = wamp.ListToStrings(filterList)
@@ -757,7 +755,7 @@ func (r *realm) sessionCount(msg *wamp.Invocation) wamp.Message {
 				Type:    wamp.INVOCATION,
 				Error:   wamp.ErrInvalidArgument,
 				Request: msg.Request,
-				Details: emptyDict,
+				Details: wamp.Dict{},
 			}
 		}
 	}
@@ -802,7 +800,7 @@ func (r *realm) sessionList(msg *wamp.Invocation) wamp.Message {
 				Type:    wamp.INVOCATION,
 				Error:   wamp.ErrInvalidArgument,
 				Request: msg.Request,
-				Details: emptyDict,
+				Details: wamp.Dict{},
 			}
 		}
 		filter, ok = wamp.ListToStrings(filterList)
@@ -811,7 +809,7 @@ func (r *realm) sessionList(msg *wamp.Invocation) wamp.Message {
 				Type:    wamp.INVOCATION,
 				Error:   wamp.ErrInvalidArgument,
 				Request: msg.Request,
-				Details: emptyDict,
+				Details: wamp.Dict{},
 			}
 		}
 	}
@@ -1060,7 +1058,7 @@ func (r *realm) testamentAdd(msg *wamp.Invocation) wamp.Message {
 	}
 	options, ok := wamp.AsDict(msg.ArgumentsKw["publish_options"])
 	if !ok {
-		options = emptyDict
+		options = wamp.Dict{}
 	}
 	scope, ok := wamp.AsString(msg.ArgumentsKw["scope"])
 	if !ok || scope == "" {
@@ -1186,7 +1184,7 @@ func (r *realm) cleanSessionDetails(details wamp.Dict) wamp.Dict {
 			continue
 		}
 		if altTrans == nil {
-			altTrans = emptyDict
+			altTrans = wamp.Dict{}
 		}
 		altTrans[n] = v
 	}
@@ -1200,7 +1198,7 @@ func makeError(req wamp.ID, uri wamp.URI) *wamp.Error {
 	return &wamp.Error{
 		Type:    wamp.INVOCATION,
 		Request: req,
-		Details: emptyDict,
+		Details: wamp.Dict{},
 		Error:   uri,
 	}
 }
@@ -1210,9 +1208,9 @@ func makeGoodbye(reason wamp.URI, message string) *wamp.Goodbye {
 	if reason == wamp.URI("") {
 		reason = wamp.CloseNormal
 	}
-	details := emptyDict
+	details := wamp.Dict{}
 	if message != "" {
-		details = wamp.Dict{"message": message}
+		details["message"] = message
 	}
 	return &wamp.Goodbye{
 		Reason:  reason,

--- a/transport/localpeer.go
+++ b/transport/localpeer.go
@@ -41,18 +41,14 @@ func LinkedPeersQSize(queueSize int) (wamp.Peer, wamp.Peer) {
 	return c, r
 }
 
-// IsLocal returns true is the wamp.Peer is a localPeer.  These do not need
-// authentication since they are part of the same process.
-func IsLocal(p wamp.Peer) bool {
-	_, ok := p.(*localPeer)
-	return ok
-}
-
 // localPeer implements Peer
 type localPeer struct {
 	rd <-chan wamp.Message
 	wr chan<- wamp.Message
 }
+
+// IsLocal returns true is the wamp.Peer is a localPeer.
+func (p *localPeer) IsLocal() bool { return true }
 
 // Recv returns the channel this peer reads incoming messages from.
 func (p *localPeer) Recv() <-chan wamp.Message { return p.rd }
@@ -77,3 +73,10 @@ func (p *localPeer) Send(msg wamp.Message) error {
 // Close closes the outgoing channel, waking any readers waiting on data from
 // this peer.
 func (p *localPeer) Close() { close(p.wr) }
+
+// DEPRECATED
+// IsLocal returns true is the wamp.Peer is a localPeer.  These do not need
+// authentication since they are part of the same process.
+func IsLocal(p wamp.Peer) bool {
+	return p.IsLocal()
+}

--- a/transport/rawsocketpeer.go
+++ b/transport/rawsocketpeer.go
@@ -186,6 +186,8 @@ func (rs *rawSocketPeer) Send(msg wamp.Message) error {
 	return wamp.SendCtx(rs.ctxSender, rs.wr, msg)
 }
 
+func (rs *rawSocketPeer) IsLocal() bool { return false }
+
 // Close closes the rawsocket peer.  This closes the local send channel, and
 // sends a close control message to the socket to tell the other side to
 // close.

--- a/transport/websocketpeer.go
+++ b/transport/websocketpeer.go
@@ -223,6 +223,8 @@ func (w *websocketPeer) Send(msg wamp.Message) error {
 	return wamp.SendCtx(w.ctxSender, w.wr, msg)
 }
 
+func (w *websocketPeer) IsLocal() bool { return false }
+
 // Close closes the websocket peer.  This closes the local send channel, and
 // sends a close control message to the websocket to tell the other side to
 // close.

--- a/wamp/peer.go
+++ b/wamp/peer.go
@@ -23,6 +23,9 @@ type Peer interface {
 
 	// Recv returns a channel of messages from the peer.
 	Recv() <-chan Message
+
+	// IsLocal returns true if the session is local.
+	IsLocal() bool
 }
 
 // RecvTimeout receives a message from a peer within the specified time.

--- a/wamp/peer_test.go
+++ b/wamp/peer_test.go
@@ -30,6 +30,8 @@ func (p *testPeer) SendCtx(ctx context.Context, msg Message) error {
 func (p *testPeer) Recv() <-chan Message { return p.in }
 func (p *testPeer) Close()               { close(p.in) }
 
+func (p *testPeer) IsLocal() bool { return true }
+
 func TestRecvTimeout(t *testing.T) {
 	p := newTestPeer()
 	msg, err := RecvTimeout(p, time.Millisecond)


### PR DESCRIPTION
If local clients modify contents of a message, this could affect the message contents received by another client. Local clients must never receive the same message instance or messages with shared contents.

- Fixes issue #235 
- Fixes problem with local client modifying `event.Arguments` of event sent to multiple subscribers.