### PR TITLE
Fix session meta procedure wamp.subscription.match

### DIFF
--- a/router/broker.go
+++ b/router/broker.go
@@ -733,22 +733,16 @@ func (b *broker) subMatch(msg *wamp.Invocation) wamp.Message {
 			sync := make(chan struct{})
 			b.actionChan <- func() {
 				if sub, ok := b.topicSubscription[topic]; ok {
-					for subscriber := range sub.subscribers {
-						subIDs = append(subIDs, subscriber.ID)
-					}
+					subIDs = append(subIDs, sub.id)
 				}
 				for pfxTopic, sub := range b.pfxTopicSubscription {
 					if topic.PrefixMatch(pfxTopic) {
-						for subscriber := range sub.subscribers {
-							subIDs = append(subIDs, subscriber.ID)
-						}
+						subIDs = append(subIDs, sub.id)
 					}
 				}
 				for wcTopic, sub := range b.wcTopicSubscription {
 					if topic.WildcardMatch(wcTopic) {
-						for subscriber := range sub.subscribers {
-							subIDs = append(subIDs, subscriber.ID)
-						}
+						subIDs = append(subIDs, sub.id)
 					}
 				}
 				close(sync)

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -1008,9 +1008,10 @@ func TestSubscriptionMetaProcedures(t *testing.T) {
 		Options: wamp.Dict{"match": "wildcard"},
 	})
 	msg = <-subscriber.Recv()
-	if _, ok = msg.(*wamp.Subscribed); !ok {
+	if subscribed, ok = msg.(*wamp.Subscribed); !ok {
 		t.Fatal("expected SUBSCRIBED, got:", msg.MessageType())
 	}
+	wcSubscriptionID := subscribed.Subscription
 
 	// Call subscription meta-procedure to get subscriptions.
 	callID = wamp.GlobalID()
@@ -1114,6 +1115,12 @@ func TestSubscriptionMetaProcedures(t *testing.T) {
 	}
 	if len(subIDs) != 2 {
 		t.Error("expected 2 subscriptions for wamp.subscription.match, got", len(subIDs))
+	}
+	if subscriptionID != subIDs[0] && subscriptionID != subIDs[1] {
+		t.Fatal("did not match subscription ID")
+	}
+	if wcSubscriptionID != subIDs[0] && wcSubscriptionID != subIDs[1] {
+		t.Fatal("did not match wildcard subscription ID")
 	}
 
 	// ----- Test wamp.subscription.get meta procedure -----


### PR DESCRIPTION
This meta procedure needs to return subscription IDs, but was returning subscriber IDs.  This PR fixes this and provides unit test to confirm.