### PR TITLE
Fix WAMPCRA with salting

### DIFF
--- a/aat/auth_test.go
+++ b/aat/auth_test.go
@@ -3,6 +3,7 @@ package aat
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -231,9 +232,10 @@ func (ks *serverKeyStore) AuthKey(authid, authmethod string) ([]byte, error) {
 	switch authmethod {
 	case "wampcra":
 		// Lookup the user's key.
-		pw := []byte(password)
+		secret := []byte(password)
 		salt := []byte(pwSalt)
-		return pbkdf2.Key(pw, salt, iterations, keylen, sha256.New), nil
+		dk := pbkdf2.Key([]byte(secret), salt, iterations, keylen, sha256.New)
+		return []byte(base64.StdEncoding.EncodeToString(dk)), nil
 	case "ticket":
 		// Lookup the user's key.
 		return []byte("ticketforjoe1234"), nil


### PR DESCRIPTION
When a derived key is created using pbkdf2, the challenge needs to be signed with the base65-encoded derived key.  Previously the challenge was signed using the raw bytes of the key.

This fixes compatability with crossbar.

Fixes issue #252