### PR TITLE
Add snap packaging

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,37 @@
+name: nexus
+base: core20
+version: git
+summary: Full-feature WAMP v2 router and client written in Go
+description: |
+  nexus is a WAMP v2 router library, client library, and a router service,
+  that implements most of the features defined in the WAMP-protocol advanced profile.
+  The nexus project is written in Go and designed for highly concurrent asynchronous I/O.
+  The nexus router provides extended functionality. The router and client interoperate
+  with other WAMP implementations.
+
+architectures:
+  - build-on: amd64
+    run-on: amd64
+
+  - build-on: arm64
+    run-on: arm64
+
+grade: stable
+confinement: strict
+compression: lzo
+
+parts:
+  nexus:
+    plugin: go
+    source: .
+    prime:
+      - bin/nexusd
+
+apps:
+  nexus:
+    command: bin/nexusd
+    plugs:
+      - network
+      - network-bind
+      - home
+


### PR DESCRIPTION
Fixes https://github.com/gammazero/nexus/issues/262

I took the time and published nexus to the Snap store. It's currently published under my name
```
name:      nexus
summary:   Full-feature WAMP v2 router and client written in Go
publisher: Omer Akram (om26er)
store-url: https://snapcraft.io/nexus
license:   unset
description: |
  nexus is a WAMP v2 router library, client library, and a router service,
  that implements most of the features defined in the WAMP-protocol advanced profile.
  The nexus project is written in Go and designed for highly concurrent asynchronous I/O.
  The nexus router provides extended functionality. The router and client interoperate
  with other WAMP implementations.
commands:
  - nexus
snap-id:      GjmjX5WP1PRFnlWpr1vu5shD6K16Xf0d
tracking:     latest/stable
refresh-date: today at 23:55 PKT
channels:
  latest/stable:    0+git.4f99579 2022-02-26 (1) 5MB -
  latest/candidate: ↑                                
  latest/beta:      ↑                                
  latest/edge:      0+git.4f99579 2022-02-26 (1) 5MB -
installed:          0+git.4f99579            (1) 5MB -
```

I'll transfer it to @gammazero if you want it eventually. We can actually setup automatic builds for Snap, so whenever there a change in this repo, the new build of nexus will automatically get published to the snap store's "edge" channel.