### PR TITLE
Client: offer all supported serializers

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -691,7 +691,7 @@ func (ks *serverKeyStore) AuthRole(authid string) (string, error) {
 
 func TestConnectContext(t *testing.T) {
 	const (
-		expect     = "dial tcp: operation was canceled"
+		expect     = "dial tcp: lookup localhost: operation was canceled"
 		unixExpect = "dial unix /tmp/wamp.sock: operation was canceled"
 	)
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -691,7 +691,7 @@ func (ks *serverKeyStore) AuthRole(authid string) (string, error) {
 
 func TestConnectContext(t *testing.T) {
 	const (
-		expect     = "dial tcp: lookup localhost: operation was canceled"
+		expect     = "dial tcp: operation was canceled"
 		unixExpect = "dial unix /tmp/wamp.sock: operation was canceled"
 	)
 

--- a/transport/rawsocketpeer.go
+++ b/transport/rawsocketpeer.go
@@ -494,7 +494,7 @@ func checkNetworkType(network string) error {
 // getProtoByte returns the RawSocket byte value for a serialization protocol.
 func getProtoByte(serialization serialize.Serialization) (byte, error) {
 	switch serialization {
-	case serialize.JSON:
+	case serialize.AUTO, serialize.JSON:
 		return rawsocketJSON, nil
 	case serialize.MSGPACK:
 		return rawsocketMsgpack, nil

--- a/transport/serialize/serializer.go
+++ b/transport/serialize/serializer.go
@@ -15,8 +15,9 @@ import (
 )
 
 const (
+	AUTO Serialization = iota
 	// Use JSON-encoded strings as a payload.
-	JSON Serialization = iota
+	JSON
 	// Use msgpack-encoded strings as a payload.
 	MSGPACK
 	// Use CBOR encoding as a payload


### PR DESCRIPTION
Without changing the user API, takes care of https://github.com/gammazero/nexus/issues/260

If no serializer is provided in the config: offer all supported
If specific serializer is request, keep the existing behavior