### PR TITLE
Dont crash if get_events called without args

### DIFF
--- a/router/broker.go
+++ b/router/broker.go
@@ -1032,6 +1032,15 @@ func (b *broker) subEventHistory(msg *wamp.Invocation) wamp.Message {
 	var untilPub wamp.ID
 	var err error
 
+	if len(msg.Arguments) == 0 {
+		return &wamp.Error{
+			Type:    msg.MessageType(),
+			Request: msg.Request,
+			Details: wamp.Dict{},
+			Error:   wamp.ErrInvalidArgument,
+		}
+	}
+
 	subId, ok := wamp.AsID(msg.Arguments[0])
 
 	if !ok {

--- a/router/broker_test.go
+++ b/router/broker_test.go
@@ -1311,4 +1311,23 @@ func TestEventHistory(t *testing.T) {
 	if ev1.Arguments[0].(int) < ev2.Arguments[0].(int) {
 		t.Fatalf("MetaRPC subEventHistory for topic %s should return records in reverse order", topic)
 	}
+
+	// Let's test reverse order
+	inv = wamp.Invocation{
+		Request:      wamp.ID(reqId),
+		Registration: 0,
+		Details:      wamp.Dict{},
+		Arguments:    wamp.List{},
+		ArgumentsKw:  wamp.Dict{},
+	}
+
+	msg = broker.subEventHistory(&inv)
+	wErr, ok := msg.(*wamp.Error)
+	if !ok {
+		t.Fatalf("MetaRPC subEventHistory for topic %s should return Error message", topic)
+	}
+
+	if wErr.Error != wamp.ErrInvalidArgument {
+		t.Fatalf("Error URI must be %s when MetaRPC subEventHistory called without arguments", wamp.ErrInvalidArgument)
+	}
 }

--- a/router/broker_test.go
+++ b/router/broker_test.go
@@ -1311,6 +1311,7 @@ func TestEventHistory(t *testing.T) {
 	if ev1.Arguments[0].(int) < ev2.Arguments[0].(int) {
 		t.Fatalf("MetaRPC subEventHistory for topic %s should return records in reverse order", topic)
 	}
+	reqId++
 
 	// Let's test with zero args
 	inv = wamp.Invocation{

--- a/router/broker_test.go
+++ b/router/broker_test.go
@@ -1312,7 +1312,7 @@ func TestEventHistory(t *testing.T) {
 		t.Fatalf("MetaRPC subEventHistory for topic %s should return records in reverse order", topic)
 	}
 
-	// Let's test reverse order
+	// Let's test with zero args
 	inv = wamp.Invocation{
 		Request:      wamp.ID(reqId),
 		Registration: 0,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description, Motivation and Context
Fixes a crash when `wamp.subscription.get_events` is called without any arguments

### What is the current behavior?
(You can also link to an open issue here)

### What is the new behavior?
(if this is a feature change)

### What kind of change does this PR introduce?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] Overall test coverage is not decreased.
- [ ] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
