### PR TITLE
Official nexusd container image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,60 @@
+name: Docker
+
+on:
+  push:
+    paths:
+      - .github/workflows/docker-publish.yml
+      - 'aat/**'
+      - 'client/**'
+      - 'nexusd/**'
+      - 'router/**'
+      - 'stdlog/**'
+      - 'transport/**'
+      - 'wamp/**'
+      - 'Dockerfile'
+      - '.dockerignore'
+    branches: [ "v3" ]
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "v3" ]
+
+env:
+  REGISTRY: ghcr.io
+  TAG: ${{ github.sha }}
+  VERSION: ${{ github.ref_type == 'tag' && github.ref_name || 'latest' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: (github.repository == 'gammazero/nexus')
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64, linux/arm64
+          build-args: BUILD_VERSION=${{ env.VERSION }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/nexusd:${{ env.VERSION }}
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/nexusd:${{ env.TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM docker.io/library/golang:latest AS build-image
+
+ARG BUILD_VERSION="latest"
+
+RUN go install github.com/gammazero/nexus/v3/nexusd@${BUILD_VERSION}
+
+FROM docker.io/library/busybox:latest AS release-image
+
+ARG BUILD_VERSION="latest"
+
+COPY --from=build-image /go/bin/nexusd /usr/bin/nexusd
+
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/bin/nexusd"]
+CMD ["--ws", "0.0.0.0:8080", "--realm", "realm1"]
+
+ENV TZ=Etc/UTC
+
+LABEL name="nexusd"
+LABEL version="${BUILD_VERSION}"
+LABEL vendor="Nexus WAMP Contributors"
+LABEL description="Nexus is a WAMP v2 router library, client library, and a router \
+service, that implements most of the features defined in the WAMP-protocol advanced profile"

--- a/README.md
+++ b/README.md
@@ -82,6 +82,28 @@ import (
 )
 ```
 
+## Run nexusd from a container
+
+Pull the nexusd container image built with the latest code version and run the container:
+
+```
+docker pull ghcr.io/gammazero/nexusd:latest
+docker run ghcr.io/gammazero/nexusd:latest
+```
+
+Now it just works. By default, the router accepts connections on port `8080` and allows anonymous communication with
+clients using `realm1`. You can change the values or get help by passing options to the container process:
+
+```
+docker run ghcr.io/gammazero/nexusd:latest --ws 0.0.0.0:8888 --realm autobahn
+docker run ghcr.io/gammazero/nexusd:latest --help
+```
+
+Alternatively, you can mount the nexusd configuration file to the container, and get a more customizable and secure
+environment. See the nexusd configuration reference for details. Finally, you can also run the container process as
+an unprivileged user.
+
+
 ## Examples
 
 Look at the examples to see how to create simple clients and servers.  Follow the


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description, Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Provides a Dockerfile for `nexusd` container, Github Actions instructions for building the container image, and adds help on using the container to the README file.
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes <https://github.com/gammazero/nexus/issues/298>.

### What is the current behavior?

There is no official `nexusd` container image.

### What is the new behavior?

The official `nexusd` container image would be provided on the GitHub container registry. The latest version will be rebuilt for every merge in the **v3** branch, numbered versions should be built when tag is added. Binary is built using the latest Go container from the Docker team. The distribution container is based on a tiny busybox image, it is small and easy to use. Instructions for using the container should be added to the README file.

Container has been tested with a Buildbot multimaster installation and works perfectly. It can be run as a privileged or unprivileged process, and it can work with a mounted configuration file.

I'm not sure if any tests need to be added here, but if they are, please let me know.

### What kind of change does this PR introduce?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] Overall test coverage is not decreased.
- [ ] All new and existing tests passed.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
