### PR TITLE
Send API returns a write-only channel

### DIFF
--- a/router/auth/crauth.go
+++ b/router/auth/crauth.go
@@ -89,12 +89,14 @@ func (cr *CRAuthenticator) Authenticate(sid wamp.ID, details wamp.Dict, client w
 	}
 
 	// Challenge response needed.  Send CHALLENGE message to client.
-	err = client.Send(&wamp.Challenge{
+	chalMsg := &wamp.Challenge{
 		AuthMethod: cr.AuthMethod(),
 		Extra:      extra,
-	})
-	if err != nil {
-		return nil, err
+	}
+	select {
+	case client.Send() <- chalMsg:
+	default:
+		return nil, errors.New("cannot send to client: blocked")
 	}
 
 	// Read AUTHENTICATE response from client.

--- a/router/auth/crauth.go
+++ b/router/auth/crauth.go
@@ -96,7 +96,7 @@ func (cr *CRAuthenticator) Authenticate(sid wamp.ID, details wamp.Dict, client w
 	select {
 	case client.Send() <- chalMsg:
 	default:
-		return nil, errors.New("cannot send to client: blocked")
+		return nil, errors.New("cannot send challenge to client: blocked")
 	}
 
 	// Read AUTHENTICATE response from client.

--- a/router/auth/crauth_test.go
+++ b/router/auth/crauth_test.go
@@ -94,10 +94,10 @@ func cliRsp(p wamp.Peer) {
 			continue
 		}
 		signature, authDetails := clientAuthFunc(ch)
-		p.Send(&wamp.Authenticate{
+		p.Send() <- &wamp.Authenticate{
 			Signature: signature,
 			Extra:     authDetails,
-		})
+		}
 	}
 }
 

--- a/router/auth/ticket.go
+++ b/router/auth/ticket.go
@@ -74,14 +74,16 @@ func (t *TicketAuthenticator) Authenticate(sid wamp.ID, details wamp.Dict, clien
 		ticket = nil
 	}
 
-	// Challenge Extra map is empty since the ticket challenge only asks for a
-	// ticket (using authmethod) and provides no additional challenge info.
-	err = client.Send(&wamp.Challenge{
+	chalMsg := &wamp.Challenge{
 		AuthMethod: t.AuthMethod(),
 		Extra:      wamp.Dict{},
-	})
-	if err != nil {
-		return nil, err
+	}
+	// Challenge Extra map is empty since the ticket challenge only asks for a
+	// ticket (using authmethod) and provides no additional challenge info.
+	select {
+	case client.Send() <- chalMsg:
+	default:
+		return nil, errors.New("Cannot send chllenge to client: blocked")
 	}
 
 	// Read AUTHENTICATE response from client.

--- a/router/auth/ticket.go
+++ b/router/auth/ticket.go
@@ -83,7 +83,7 @@ func (t *TicketAuthenticator) Authenticate(sid wamp.ID, details wamp.Dict, clien
 	select {
 	case client.Send() <- chalMsg:
 	default:
-		return nil, errors.New("Cannot send chllenge to client: blocked")
+		return nil, errors.New("Cannot send challenge to client: blocked")
 	}
 
 	// Read AUTHENTICATE response from client.

--- a/router/authorizer_test.go
+++ b/router/authorizer_test.go
@@ -59,13 +59,13 @@ func TestAuthorizer(t *testing.T) {
 
 	// Test that authorizer forbids denyTopic.
 	subscribeID := wamp.GlobalID()
-	sub.Send(&wamp.Subscribe{Request: subscribeID, Topic: denyTopic})
+	sub.Send() <- &wamp.Subscribe{Request: subscribeID, Topic: denyTopic}
 	msg := <-sub.Recv()
 	_, ok := msg.(*wamp.Error)
 	require.True(t, ok, "Expected ERROR")
 
 	// Test that authorizer allows allowTopic.
-	sub.Send(&wamp.Subscribe{Request: subscribeID, Topic: allowTopic})
+	sub.Send() <- &wamp.Subscribe{Request: subscribeID, Topic: allowTopic}
 	msg = <-sub.Recv()
 	_, ok = msg.(*wamp.Subscribed)
 	require.True(t, ok, "Expected SUBSCRIBED")
@@ -90,7 +90,7 @@ func TestAuthorizerBypassLocal(t *testing.T) {
 	sub := testClient(t, r)
 
 	subscribeID := wamp.GlobalID()
-	sub.Send(&wamp.Subscribe{Request: subscribeID, Topic: denyTopic})
+	sub.Send() <- &wamp.Subscribe{Request: subscribeID, Topic: denyTopic}
 	msg := <-sub.Recv()
 	_, ok := msg.(*wamp.Subscribed)
 	require.True(t, ok, "Expected SUBSCRIBED")
@@ -113,11 +113,11 @@ func TestAuthorizerModify(t *testing.T) {
 
 	cli := testClient(t, r)
 	for i := 1; i <= 10; i++ {
-		cli.Send(&wamp.Call{
+		cli.Send() <- &wamp.Call{
 			Request:   wamp.ID(i),
 			Procedure: wamp.MetaProcSessionGet,
 			Arguments: wamp.List{cli.ID},
-		})
+		}
 		msg, err := wamp.RecvTimeout(cli, time.Second)
 		require.NoError(t, err)
 		result, ok := msg.(*wamp.Result)
@@ -157,7 +157,7 @@ func TestAuthorizerRace(t *testing.T) {
 	// Test that authorizer forbids denyTopic.
 	subscribeID := wamp.GlobalID()
 	const topic = "whatever.topic"
-	sub.Send(&wamp.Subscribe{Request: subscribeID, Topic: topic})
+	sub.Send() <- &wamp.Subscribe{Request: subscribeID, Topic: topic}
 	msg, err := wamp.RecvTimeout(sub, time.Second)
 	require.NoError(t, err)
 	_, ok := msg.(*wamp.Subscribed)
@@ -166,39 +166,39 @@ func TestAuthorizerRace(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		for i := 0; i < 100; i++ {
-			pub.Send(&wamp.Publish{
+			pub.Send() <- &wamp.Publish{
 				Request: wamp.ID(i),
 				Topic:   topic,
 				Options: wamp.Dict{"eligible_xyzzy": wamp.List{"plugh", "baz"}},
-			})
+			}
 		}
 		done <- struct{}{}
 	}()
 
 	go func() {
 		for i := 0; i < 100; i++ {
-			cli.Send(&wamp.Call{
+			cli.Send() <- &wamp.Call{
 				Request:   wamp.ID(100 + i),
 				Procedure: wamp.MetaProcSessionGet,
 				Arguments: wamp.List{pub.ID},
-			})
+			}
 			<-cli.Recv()
-			cli.Send(&wamp.Call{
+			cli.Send() <- &wamp.Call{
 				Request:   wamp.ID(200 + i),
 				Procedure: wamp.MetaProcSessionGet,
 				Arguments: wamp.List{sub.ID},
-			})
+			}
 			<-cli.Recv()
 		}
 		done <- struct{}{}
 	}()
 
 	for i := 0; i < 100; i++ {
-		sub.Send(&wamp.Publish{
+		sub.Send() <- &wamp.Publish{
 			Request: wamp.ID(500 + i),
 			Topic:   topic,
 			Options: wamp.Dict{"eligible_xyzzy": wamp.List{"plugh"}},
-		})
+		}
 	}
 	<-done
 	<-done

--- a/router/broker_test.go
+++ b/router/broker_test.go
@@ -1,7 +1,6 @@
 package router
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -19,20 +18,8 @@ func newTestPeer() *testPeer {
 	}
 }
 
-func (p *testPeer) TrySend(msg wamp.Message) error {
-	return wamp.TrySend(p.in, msg)
-}
-
-func (p *testPeer) Send(msg wamp.Message) error {
-	p.in <- msg
-	return nil
-}
-
-func (p *testPeer) SendCtx(ctx context.Context, msg wamp.Message) error {
-	return wamp.SendCtx(ctx, p.in, msg)
-}
-
 func (p *testPeer) Recv() <-chan wamp.Message { return p.in }
+func (p *testPeer) Send() chan<- wamp.Message { return p.in }
 func (p *testPeer) Close()                    {}
 
 func (p *testPeer) IsLocal() bool { return true }

--- a/router/rawsocketserver_test.go
+++ b/router/rawsocketserver_test.go
@@ -27,7 +27,7 @@ func TestRSHandshakeJSON(t *testing.T) {
 	require.NoError(t, err)
 	defer client.Close()
 
-	client.Send(&wamp.Hello{Realm: testRealm, Details: clientRoles})
+	client.Send() <- &wamp.Hello{Realm: testRealm, Details: clientRoles}
 	msg, ok := <-client.Recv()
 	require.True(t, ok, "recv chan closed")
 
@@ -50,7 +50,7 @@ func TestRSHandshakeMsgpack(t *testing.T) {
 	require.NoError(t, err)
 	defer client.Close()
 
-	client.Send(&wamp.Hello{Realm: testRealm, Details: clientRoles})
+	client.Send() <- &wamp.Hello{Realm: testRealm, Details: clientRoles}
 	msg, ok := <-client.Recv()
 	require.True(t, ok, "Receive buffer closed")
 

--- a/router/router.go
+++ b/router/router.go
@@ -145,7 +145,7 @@ func (r *router) AttachClient(client wamp.Peer, transportDetails wamp.Dict) erro
 			abortMsg.Details[wamp.OptMessage] = abortErr.Error()
 			r.log.Println("Aborting client connection:", abortErr)
 		}
-		client.Send(&abortMsg) // Blocking OK; this is session goroutine.
+		client.Send() <- &abortMsg // Blocking OK; this is session goroutine.
 		client.Close()
 	}
 
@@ -282,7 +282,7 @@ func (r *router) AttachClient(client wamp.Peer, transportDetails wamp.Dict) erro
 		return err
 	}
 
-	client.Send(welcome) // Blocking OK; this is session goroutine.
+	client.Send() <- welcome // Blocking OK; this is session goroutine.
 	if r.debug {
 		r.log.Println("Finished attaching session:", sid)
 	}

--- a/router/sessionkill_test.go
+++ b/router/sessionkill_test.go
@@ -20,11 +20,12 @@ func TestSessionKill(t *testing.T) {
 	message := "this is a test"
 
 	// Request that client-3 be killed.
-	cli1.Send(&wamp.Call{
+	cli1.Send() <- &wamp.Call{
 		Request:     wamp.GlobalID(),
 		Procedure:   wamp.MetaProcSessionKill,
 		Arguments:   wamp.List{cli3.ID},
-		ArgumentsKw: wamp.Dict{"reason": reason, "message": message}})
+		ArgumentsKw: wamp.Dict{"reason": reason, "message": message},
+	}
 
 	msg, err := wamp.RecvTimeout(cli1, time.Second)
 	require.NoError(t, err)
@@ -45,11 +46,12 @@ func TestSessionKill(t *testing.T) {
 	require.Error(t, err, "Expected timeout")
 
 	// Test that killing self gets error.
-	cli1.Send(&wamp.Call{
+	cli1.Send() <- &wamp.Call{
 		Request:     wamp.GlobalID(),
 		Procedure:   wamp.MetaProcSessionKill,
 		Arguments:   wamp.List{cli1.ID},
-		ArgumentsKw: nil})
+		ArgumentsKw: nil,
+	}
 
 	msg, err = wamp.RecvTimeout(cli1, time.Second)
 	require.NoError(t, err)
@@ -69,10 +71,11 @@ func TestSessionKillAll(t *testing.T) {
 	reason := wamp.URI("foo.bar.baz")
 	message := "this is a test"
 
-	cli1.Send(&wamp.Call{
+	cli1.Send() <- &wamp.Call{
 		Request:     wamp.GlobalID(),
 		Procedure:   wamp.MetaProcSessionKillAll,
-		ArgumentsKw: wamp.Dict{"reason": reason, "message": message}})
+		ArgumentsKw: wamp.Dict{"reason": reason, "message": message},
+	}
 
 	msg, err := wamp.RecvTimeout(cli1, time.Second)
 	require.NoError(t, err)
@@ -112,11 +115,12 @@ func TestSessionKillByAuthid(t *testing.T) {
 
 	// All clients have the same authid, so killing by authid should kill all
 	// except the requesting client.
-	cli1.Send(&wamp.Call{
+	cli1.Send() <- &wamp.Call{
 		Request:     wamp.GlobalID(),
 		Procedure:   wamp.MetaProcSessionKillByAuthid,
 		Arguments:   wamp.List{cli1.Details["authid"]},
-		ArgumentsKw: wamp.Dict{"reason": reason, "message": message}})
+		ArgumentsKw: wamp.Dict{"reason": reason, "message": message},
+	}
 
 	msg, err := wamp.RecvTimeout(cli1, time.Second)
 	require.NoError(t, err)
@@ -156,11 +160,11 @@ func TestSessionModifyDetails(t *testing.T) {
 	// Call session meta-procedure to get session information.
 	callID := wamp.GlobalID()
 	delta := wamp.Dict{"xyzzy": nil, "pi": 3.14, "authid": "bob"}
-	caller.Send(&wamp.Call{
+	caller.Send() <- &wamp.Call{
 		Request:   callID,
 		Procedure: wamp.MetaProcSessionModifyDetails,
 		Arguments: wamp.List{caller.ID, delta},
-	})
+	}
 	msg, err := wamp.RecvTimeout(caller, time.Second)
 	require.NoError(t, err)
 	result, ok := msg.(*wamp.Result)
@@ -169,11 +173,11 @@ func TestSessionModifyDetails(t *testing.T) {
 
 	// Call session meta-procedure to get session information.
 	callID = wamp.GlobalID()
-	caller.Send(&wamp.Call{
+	caller.Send() <- &wamp.Call{
 		Request:   callID,
 		Procedure: wamp.MetaProcSessionGet,
 		Arguments: wamp.List{sessID},
-	})
+	}
 	msg, err = wamp.RecvTimeout(caller, time.Second)
 	require.NoError(t, err)
 	result, ok = msg.(*wamp.Result)

--- a/router/testaments_test.go
+++ b/router/testaments_test.go
@@ -14,13 +14,13 @@ func TestSessionTestaments(t *testing.T) {
 
 	sub := testClient(t, r)
 	subscribeID := wamp.GlobalID()
-	sub.Send(&wamp.Subscribe{Request: subscribeID, Topic: "testament.test1"})
+	sub.Send() <- &wamp.Subscribe{Request: subscribeID, Topic: "testament.test1"}
 	msg, err := wamp.RecvTimeout(sub, time.Second)
 	require.NoError(t, err)
 	_, ok := msg.(*wamp.Subscribed)
 	require.True(t, ok, "expected RESULT")
 
-	sub.Send(&wamp.Subscribe{Request: subscribeID, Topic: "testament.test2"})
+	sub.Send() <- &wamp.Subscribe{Request: subscribeID, Topic: "testament.test2"}
 	msg, err = wamp.RecvTimeout(sub, time.Second)
 	require.NoError(t, err)
 	require.NotNil(t, msg)
@@ -29,7 +29,7 @@ func TestSessionTestaments(t *testing.T) {
 	caller2 := testClient(t, r)
 
 	callID := wamp.GlobalID()
-	caller1.Send(&wamp.Call{
+	caller1.Send() <- &wamp.Call{
 		Request:   callID,
 		Procedure: wamp.MetaProcSessionAddTestament,
 		Arguments: wamp.List{
@@ -37,7 +37,7 @@ func TestSessionTestaments(t *testing.T) {
 			wamp.List{"foo"},
 			wamp.Dict{},
 		},
-	})
+	}
 
 	msg, err = wamp.RecvTimeout(caller1, time.Second)
 	require.NoError(t, err)
@@ -45,7 +45,7 @@ func TestSessionTestaments(t *testing.T) {
 	require.True(t, ok, "expected RESULT")
 	require.Equal(t, callID, result.Request, "wrong result ID")
 
-	caller2.Send(&wamp.Call{
+	caller2.Send() <- &wamp.Call{
 		Request:   wamp.GlobalID(),
 		Procedure: wamp.MetaProcSessionAddTestament,
 		Arguments: wamp.List{
@@ -53,7 +53,7 @@ func TestSessionTestaments(t *testing.T) {
 			wamp.List{"foo"},
 			wamp.Dict{},
 		},
-	})
+	}
 
 	msg, err = wamp.RecvTimeout(caller2, time.Second)
 	require.NoError(t, err)

--- a/router/websocketserver_test.go
+++ b/router/websocketserver_test.go
@@ -50,7 +50,7 @@ func TestWSHandshakeJSON(t *testing.T) {
 	require.NoError(t, err)
 	defer client.Close()
 
-	client.Send(&wamp.Hello{Realm: testRealm, Details: clientRoles})
+	client.Send() <- &wamp.Hello{Realm: testRealm, Details: clientRoles}
 	msg, ok := <-client.Recv()
 	require.True(t, ok, "recv chan closed")
 
@@ -74,7 +74,7 @@ func TestWSHandshakeMsgpack(t *testing.T) {
 	require.NoError(t, err)
 	defer client.Close()
 
-	client.Send(&wamp.Hello{Realm: testRealm, Details: clientRoles})
+	client.Send() <- &wamp.Hello{Realm: testRealm, Details: clientRoles}
 	msg, ok := <-client.Recv()
 	require.True(t, ok, "Receive buffer closed")
 

--- a/transport/localpeer.go
+++ b/transport/localpeer.go
@@ -1,8 +1,6 @@
 package transport
 
 import (
-	"context"
-
 	"github.com/gammazero/nexus/v3/wamp"
 )
 
@@ -53,30 +51,9 @@ func (p *localPeer) IsLocal() bool { return true }
 // Recv returns the channel this peer reads incoming messages from.
 func (p *localPeer) Recv() <-chan wamp.Message { return p.rd }
 
-// TrySend writes a message to the peer's outbound message channel.
-func (p *localPeer) TrySend(msg wamp.Message) error {
-	return wamp.TrySend(p.wr, msg)
-}
-
-func (p *localPeer) SendCtx(ctx context.Context, msg wamp.Message) error {
-	return wamp.SendCtx(ctx, p.wr, msg)
-}
-
-// Send writes a message to the peer's outbound message channel.
-// Typically called by clients, since it is OK for the router to block a client
-// since this will not block other clients.
-func (p *localPeer) Send(msg wamp.Message) error {
-	p.wr <- msg
-	return nil
-}
+// Send returns the peer's outbound message channel.
+func (p *localPeer) Send() chan<- wamp.Message { return p.wr }
 
 // Close closes the outgoing channel, waking any readers waiting on data from
 // this peer.
 func (p *localPeer) Close() { close(p.wr) }
-
-// DEPRECATED
-// IsLocal returns true is the wamp.Peer is a localPeer.  These do not need
-// authentication since they are part of the same process.
-func IsLocal(p wamp.Peer) bool {
-	return p.IsLocal()
-}

--- a/transport/rawsocketpeer.go
+++ b/transport/rawsocketpeer.go
@@ -173,17 +173,7 @@ func newRawSocketPeer(conn net.Conn, serializer serialize.Serializer, logger std
 
 func (rs *rawSocketPeer) Recv() <-chan wamp.Message { return rs.rd }
 
-func (rs *rawSocketPeer) TrySend(msg wamp.Message) error {
-	return wamp.TrySend(rs.wr, msg)
-}
-
-func (rs *rawSocketPeer) SendCtx(ctx context.Context, msg wamp.Message) error {
-	return wamp.SendCtx(ctx, rs.wr, msg)
-}
-
-func (rs *rawSocketPeer) Send(msg wamp.Message) error {
-	return wamp.SendCtx(rs.ctxSender, rs.wr, msg)
-}
+func (rs *rawSocketPeer) Send() chan<- wamp.Message { return rs.wr }
 
 func (rs *rawSocketPeer) IsLocal() bool { return false }
 

--- a/transport/rawsocketpeer.go
+++ b/transport/rawsocketpeer.go
@@ -187,6 +187,9 @@ func (rs *rawSocketPeer) Close() {
 	// wr channel in case there are incoming messages during close.
 	rs.cancelSender()
 	<-rs.writerDone
+	close(rs.wr)
+	for range rs.wr {
+	}
 
 	// Tell recvHandler to close.
 	close(rs.closed)

--- a/transport/websocketpeer.go
+++ b/transport/websocketpeer.go
@@ -223,17 +223,7 @@ func NewWebsocketPeer(conn WebsocketConnection, serializer serialize.Serializer,
 
 func (w *websocketPeer) Recv() <-chan wamp.Message { return w.rd }
 
-func (w *websocketPeer) TrySend(msg wamp.Message) error {
-	return wamp.TrySend(w.wr, msg)
-}
-
-func (w *websocketPeer) SendCtx(ctx context.Context, msg wamp.Message) error {
-	return wamp.SendCtx(ctx, w.wr, msg)
-}
-
-func (w *websocketPeer) Send(msg wamp.Message) error {
-	return wamp.SendCtx(w.ctxSender, w.wr, msg)
-}
+func (w *websocketPeer) Send() chan<- wamp.Message { return w.wr }
 
 func (w *websocketPeer) IsLocal() bool { return false }
 

--- a/transport/websocketpeer.go
+++ b/transport/websocketpeer.go
@@ -237,6 +237,9 @@ func (w *websocketPeer) Close() {
 	// wr channel in case there are incoming messages during close.
 	w.cancelSender()
 	<-w.writerDone
+	close(w.wr)
+	for range w.wr {
+	}
 
 	closeMsg := websocket.FormatCloseMessage(websocket.CloseNormalClosure,
 		"goodbye")

--- a/wamp/peer.go
+++ b/wamp/peer.go
@@ -1,64 +1,37 @@
 package wamp
 
 import (
-	"context"
 	"errors"
 	"time"
 )
 
 // Peer is the interface implemented by endpoints communicating via WAMP.
 type Peer interface {
-	// Sends the message to the peer.
-	Send(Message) error
-
-	// SendCtx sends the message to the peer, and uses a context to cancel or
-	// timeout sending the message when blocked waiting to write to the peer.
-	SendCtx(context.Context, Message) error
-
-	// TrySend performs a non-blocking send.  Returns error if blocked.
-	TrySend(Message) error
-
 	// Closes the peer connection and the channel returned from Recv().
 	Close()
+
+	// IsLocal returns true if the session is local.
+	IsLocal() bool
 
 	// Recv returns a channel of messages from the peer.
 	Recv() <-chan Message
 
-	// IsLocal returns true if the session is local.
-	IsLocal() bool
+	// Send returns the peer's outgoing message channel.
+	Send() chan<- Message
 }
 
 // RecvTimeout receives a message from a peer within the specified time.
-func RecvTimeout(p Peer, t time.Duration) (Message, error) {
+func RecvTimeout(p Peer, timeout time.Duration) (Message, error) {
+	to := time.NewTimer(timeout)
+	defer to.Stop()
+
 	select {
 	case msg, open := <-p.Recv():
 		if !open {
 			return nil, errors.New("receive channel closed")
 		}
 		return msg, nil
-	case <-time.After(t):
+	case <-to.C:
 		return nil, errors.New("timeout waiting for message")
 	}
-}
-
-// SendCtx sends a message to the write-only channel, using a context to cancel
-// sending if blocked.
-func SendCtx(ctx context.Context, wr chan<- Message, msg Message) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case wr <- msg:
-	}
-	return nil
-}
-
-// TrySend sends a message to the write-only channel and returns an error if
-// the channel blocks.
-func TrySend(wr chan<- Message, msg Message) error {
-	select {
-	case wr <- msg:
-	default:
-		return errors.New("blocked")
-	}
-	return nil
 }

--- a/wamp/peer_test.go
+++ b/wamp/peer_test.go
@@ -1,7 +1,6 @@
 package wamp
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -16,19 +15,7 @@ func newTestPeer() Peer {
 	return &testPeer{make(chan Message)}
 }
 
-func (p *testPeer) TrySend(msg Message) error {
-	return TrySend(p.in, msg)
-}
-
-func (p *testPeer) Send(msg Message) error {
-	p.in <- msg
-	return nil
-}
-
-func (p *testPeer) SendCtx(ctx context.Context, msg Message) error {
-	return SendCtx(ctx, p.in, msg)
-}
-
+func (p *testPeer) Send() chan<- Message { return p.in }
 func (p *testPeer) Recv() <-chan Message { return p.in }
 func (p *testPeer) Close()               { close(p.in) }
 
@@ -41,7 +28,7 @@ func TestRecvTimeout(t *testing.T) {
 	require.Nil(t, msg)
 
 	go func() {
-		p.Send(&Hello{})
+		p.Send() <- &Hello{}
 	}()
 	msg, err = RecvTimeout(p, time.Millisecond)
 	require.NoError(t, err)
@@ -50,37 +37,4 @@ func TestRecvTimeout(t *testing.T) {
 	p.Close()
 	_, err = RecvTimeout(p, time.Millisecond)
 	require.EqualError(t, err, "receive channel closed")
-}
-
-func TestTrySend(t *testing.T) {
-	p := newTestPeer()
-	err := p.TrySend(&Hello{})
-	require.Error(t, err)
-
-	ready := make(chan struct{})
-	go func() {
-		close(ready)
-		<-p.Recv()
-	}()
-	<-ready
-
-	err = p.TrySend(&Hello{})
-	require.NoError(t, err)
-
-	p.Close()
-}
-
-func TestSendCtx(t *testing.T) {
-	p := newTestPeer()
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		<-p.Recv()
-	}()
-	err := p.SendCtx(ctx, &Hello{})
-	require.NoError(t, err)
-
-	cancel()
-	err = p.SendCtx(ctx, &Hello{})
-	require.ErrorIs(t, err, context.Canceled)
-	p.Close()
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

### Description, Motivation and Context
This PR simplifies APIs by removing `TrySend` and `SendCtx`, and allows the caller of `Send` more flexability. More flexibility is provided by a channel as it allows the caller to choose to use it in a select, range loop, etc. when writing a message.

Addresses Issue #291

### What is the current behavior?
A message is passed into the blocking `Send` or non-blocking `TrySend`, or a message and context is passed into `SendCtx`.

### What is the new behavior?
The `Send` function returns a write-only message channel. The `TrySend` and `SendCtx` functions disappear.

### What kind of change does this PR introduce?
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

_This might not be considered a breaking change if `Send` is considered an internal API used when writing your own router or client implementation using the `wamp` package. You can see this is the case since all of the [examples](https://github.com/gammazero/nexus/tree/v3/examples) do not need to change._

### Checklist:
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] Overall test coverage is not decreased.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
