### PR TITLE
allow users to modify attributes of the tracking cookie

### DIFF
--- a/router/websocketserver.go
+++ b/router/websocketserver.go
@@ -85,6 +85,12 @@ type WebsocketServer struct {
 	// Details.transport.auth.request|*http.Request making it available to
 	// authenticator and authorizer logic.
 	EnableRequestCapture bool
+	// TrackingCookieSameSiteAttribute defines which SameSite attribute will be assigned to
+	// the next auth cookie if EnableTrackingCookie is true
+	TrackingCookieSameSiteAttribute http.SameSite
+	// TrackingCookieSecureAttribute defines whether the TrackingCookie should be marked as
+	// secure and thus only sent over encrypted connections.
+	TrackingCookieSecureAttribute bool
 
 	// KeepAlive configures a websocket "ping/pong" heartbeat when set to a
 	// non-zero value.  KeepAlive is the interval between websocket "pings".
@@ -305,8 +311,10 @@ func (s *WebsocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if err == nil {
 			// Create next auth cookie with 20 byte random value.
 			nextCookie = &http.Cookie{
-				Name:  cookieName,
-				Value: base64.URLEncoding.EncodeToString(b),
+				Name:     cookieName,
+				Value:    base64.URLEncoding.EncodeToString(b),
+				Secure:   s.TrackingCookieSecureAttribute,
+				SameSite: s.TrackingCookieSameSiteAttribute,
 			}
 			http.SetCookie(w, nextCookie)
 			authDict["nextcookie"] = nextCookie


### PR DESCRIPTION
### Description, Motivation and Context
When using the Nexus Websockets tracking cookie option it might be necessary to modify the cookie attributes.  This is helpful when using Nexus WAMP over Websockets from a Web browser.   Web browsers vary on the handling of cookies received.

### What is the current behavior?
RESOLVES #295 

### What is the new behavior?
This change exposes two new websocket server settings that can be modified by the user.  These settings control which SameSite mode that the nexus-wamp-cookie will be sent back with.  Further, it allows the user to set the Secure attribute of the cookie to restrict the cookie to secure connections.

### What kind of change does this PR introduce?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] Overall test coverage is not decreased.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.


(this is my first attempt at a PR of any kind.  Please let me know what I might have missed)