### PR TITLE
RPC forward_timeout option

### DIFF
--- a/aat/rpc_progress_test.go
+++ b/aat/rpc_progress_test.go
@@ -384,7 +384,7 @@ func TestRPCProgressiveCallTimeout(t *testing.T) {
 	require.Error(t, err, "expected error from CallProgress")
 	var rpce client.RPCError
 	require.ErrorAs(t, err, &rpce, "error should be RPCError type")
-	require.Equal(t, wamp.ErrCanceled, rpce.Err.Error)
+	require.Equal(t, wamp.ErrTimeout, rpce.Err.Error)
 	close(releaseCallee)
 
 	select {

--- a/aat/rpc_test.go
+++ b/aat/rpc_test.go
@@ -215,7 +215,7 @@ func TestRPCTimeoutCall(t *testing.T) {
 		require.Error(t, err)
 		var rpcErr client.RPCError
 		require.ErrorAs(t, err, &rpcErr)
-		require.Equal(t, wamp.ErrCanceled, rpcErr.Err.Error)
+		require.Equal(t, wamp.ErrTimeout, rpcErr.Err.Error)
 	case <-time.After(2 * time.Second):
 		require.FailNow(t, "call should have been canceled")
 	}
@@ -229,7 +229,7 @@ func TestRPCTimeoutCall(t *testing.T) {
 
 	var rpcError client.RPCError
 	require.ErrorAs(t, err, &rpcError)
-	require.Equal(t, wamp.ErrCanceled, rpcError.Err.Error)
+	require.Equal(t, wamp.ErrTimeout, rpcError.Err.Error)
 
 	err = callee.Unregister(procName)
 	require.NoError(t, err)

--- a/client/client.go
+++ b/client/client.go
@@ -1687,7 +1687,7 @@ func (c *Client) runHandleInvocation(msg *wamp.Invocation) {
 				case result = <-resChan:
 					// If the handler returns InvocationCanceled, this means the
 					// handler canceled the call.
-					if result.Err == wamp.ErrCanceled {
+					if result.Err == wamp.ErrCanceled || result.Err == wamp.ErrTimeout {
 						c.log.Println("INVOCATION", reqID, "canceled by callee")
 						isProcessing = false
 						break

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -904,7 +904,7 @@ func TestTimeoutRemoteProcedureCall(t *testing.T) {
 	case err = <-errChan:
 		var rpcError RPCError
 		require.ErrorAs(t, err, &rpcError)
-		require.Equal(t, wamp.ErrCanceled, rpcError.Err.Error)
+		require.Equal(t, wamp.ErrTimeout, rpcError.Err.Error)
 	case <-time.After(2 * time.Second):
 		require.FailNow(t, "call should have been canceled")
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -574,6 +574,9 @@ func TestProgressiveCallResults(t *testing.T) {
 
 	// Handler sends progressive results.
 	handler := func(ctx context.Context, inv *wamp.Invocation) InvokeResult {
+		// Creating another child context to check that progressive results
+		// work as expected even with another child context passed.
+		ctx = context.WithValue(ctx, "Some-key", true)
 		senderr := callee.SendProgress(ctx, wamp.List{"Alpha"}, nil)
 		if senderr != nil {
 			fmt.Println("Error sending Alpha progress:", senderr)

--- a/router/dealer.go
+++ b/router/dealer.go
@@ -867,6 +867,13 @@ func (d *dealer) syncCall(caller *wamp.Session, msg *wamp.Call) {
 		return
 	}
 
+	// If the Callee does not support Call Timeouts, a Dealer supporting this feature MUST
+	// start a timeout timer upon receiving a CALL message with a timeout option. The message
+	// flow for call timeouts is identical to Call Canceling, except that there is no
+	// CANCEL message that originates from the Caller. The cancellation mode is implicitly
+	// killnowait if the Callee supports call cancellation, otherwise the cancellation mode is skip.
+	//
+	// The error message that is returned to the Caller MUST use wamp.error.timeout as the reason URI.
 	if timeout > 0 {
 		// Timer removed if context canceled, call cancelled if timeout.
 		var timerCtx context.Context
@@ -886,7 +893,7 @@ func (d *dealer) syncCall(caller *wamp.Session, msg *wamp.Call) {
 			d.actionChan <- func() {
 				errArgs := wamp.List{"call timeout"}
 				d.syncCancel(caller, &wamp.Cancel{Request: msg.Request},
-					wamp.CancelModeKillNoWait, wamp.ErrCanceled, errArgs)
+					wamp.CancelModeKillNoWait, wamp.ErrTimeout, errArgs)
 			}
 		}()
 	}

--- a/router/dealer.go
+++ b/router/dealer.go
@@ -40,13 +40,14 @@ var dealerRole = wamp.Dict{
 
 // remoteProcedure tracks in-progress remote procedure call
 type registration struct {
-	id         wamp.ID  // registration ID
-	procedure  wamp.URI // procedure this registration is for
-	created    string   // when registration was created
-	match      string   // how procedure uri is matched to registration
-	policy     string   // how callee is selected if shared registration
-	disclose   bool     // callee requests disclosure of caller identity
-	nextCallee int      // choose callee for round-robin invocation.
+	id             wamp.ID  // registration ID
+	procedure      wamp.URI // procedure this registration is for
+	created        string   // when registration was created
+	match          string   // how procedure uri is matched to registration
+	policy         string   // how callee is selected if shared registration
+	disclose       bool     // callee requests disclosure of caller identity
+	forwardTimeout bool     // callee requests to handle the timeout logic
+	nextCallee     int      // choose callee for round-robin invocation.
 
 	// Multiple sessions can register as callees depending on invocation policy
 	// resulting in multiple procedures for the same registration ID.
@@ -192,7 +193,7 @@ func (d *dealer) register(callee *wamp.Session, msg *wamp.Register) {
 	wampURI := strings.HasPrefix(string(msg.Procedure), "wamp.")
 
 	// Disallow registration of procedures starting with "wamp." by sessions
-	// other then the meta session.
+	// other than the meta session.
 	if wampURI && callee.ID != metaID {
 		errMsg := fmt.Sprintf("register for restricted procedure URI %v",
 			msg.Procedure)
@@ -226,10 +227,11 @@ func (d *dealer) register(callee *wamp.Session, msg *wamp.Register) {
 	}
 
 	invoke, _ := wamp.AsString(msg.Options[wamp.OptInvoke])
+	forwardTimeout, _ := msg.Options[wamp.OptForwardTimeout].(bool)
 	var metaPubs []*wamp.Publish
 	done := make(chan struct{})
 	d.actionChan <- func() {
-		metaPubs = d.syncRegister(callee, msg, match, invoke, disclose, wampURI)
+		metaPubs = d.syncRegister(callee, msg, match, invoke, disclose, forwardTimeout, wampURI)
 		close(done)
 	}
 	<-done
@@ -410,7 +412,7 @@ func (d *dealer) run() {
 	close(d.stopped)
 }
 
-func (d *dealer) syncRegister(callee *wamp.Session, msg *wamp.Register, match, invokePolicy string, disclose, wampURI bool) []*wamp.Publish { //nolint:lll
+func (d *dealer) syncRegister(callee *wamp.Session, msg *wamp.Register, match, invokePolicy string, disclose, forwardTimeout, wampURI bool) []*wamp.Publish { //nolint:lll
 	var metaPubs []*wamp.Publish
 	var reg *registration
 	switch match {
@@ -430,13 +432,14 @@ func (d *dealer) syncRegister(callee *wamp.Session, msg *wamp.Register, match, i
 		regID = d.idGen.Next()
 		created = wamp.NowISO8601()
 		reg = &registration{
-			id:        regID,
-			procedure: msg.Procedure,
-			created:   created,
-			match:     match,
-			policy:    invokePolicy,
-			disclose:  disclose,
-			callees:   []*wamp.Session{callee},
+			id:             regID,
+			procedure:      msg.Procedure,
+			created:        created,
+			match:          match,
+			policy:         invokePolicy,
+			disclose:       disclose,
+			forwardTimeout: forwardTimeout,
+			callees:        []*wamp.Session{callee},
 		}
 		d.registrations[regID] = reg
 		switch match {
@@ -470,7 +473,7 @@ func (d *dealer) syncRegister(callee *wamp.Session, msg *wamp.Register, match, i
 		// invocation policy allows another.
 
 		// Found an existing registration that has an invocation strategy that
-		// only allows a single callee on a the given registration.
+		// only allows a single callee on the given registration.
 		if reg.policy == "" || reg.policy == wamp.InvokeSingle {
 			d.log.Println("REGISTER for already registered procedure",
 				msg.Procedure, "from callee", callee)
@@ -642,6 +645,7 @@ func (d *dealer) syncCall(caller *wamp.Session, msg *wamp.Call) {
 	var callee *wamp.Session
 	var invocationID wamp.ID
 	var invk *invocation
+	var timeout int64
 
 	callReqID := requestID{
 		session: caller.ID,
@@ -821,15 +825,23 @@ func (d *dealer) syncCall(caller *wamp.Session, msg *wamp.Call) {
 	//
 	// A timeout allows to automatically cancel a call after a specified time
 	// either at the Callee or at the Dealer.
-	timeout, _ := wamp.AsInt64(invk.options[wamp.OptTimeout])
-	if timeout > 0 {
-		// Check that callee supports call_timeout.
-		if callee.HasFeature(wamp.RoleCallee, wamp.FeatureCallTimeout) {
+	//
+	// Callees wanting to handle the timeout logic MAY specify this intention via
+	// the REGISTER.Options.forward_timeout|boolean option. The Dealer, upon receiving
+	// a CALL with the timeout option set, checks if the matching RPC registration had
+	// the forward_timeout option set, then accordingly either forwards the timeout value
+	// or handles the timeout logic locally without forwarding the timeout value.
+	callerTimeout, _ := wamp.AsInt64(invk.options[wamp.OptTimeout])
+	if callerTimeout > 0 {
+		// Check that callee supports call_timeout and requested forward_timeout -
+		// if YES then propagate timeout value and handling to the callee side
+		if callee.HasFeature(wamp.RoleCallee, wamp.FeatureCallTimeout) && reg.forwardTimeout {
 			if !ok { // Propagate the option only during first progressive call
-				details[wamp.OptTimeout] = timeout
+				details[wamp.OptTimeout] = callerTimeout
 			}
 		} else {
-			timeout = 0
+			// Callee doesn't support timeouts so let's handle it on the dealer's side
+			timeout = callerTimeout
 		}
 	}
 
@@ -855,7 +867,7 @@ func (d *dealer) syncCall(caller *wamp.Session, msg *wamp.Call) {
 		return
 	}
 
-	if timeout != 0 {
+	if timeout > 0 {
 		// Timer removed if context canceled, call cancelled if timeout.
 		var timerCtx context.Context
 		timerCtx, invk.timerCancel = context.WithTimeout(context.Background(),

--- a/router/dealer_test.go
+++ b/router/dealer_test.go
@@ -300,7 +300,7 @@ func TestCallTimeoutOnRouter(t *testing.T) {
 	// Check that caller receives the ERROR message.
 	rslt, ok := rsp.(*wamp.Error)
 	require.True(t, ok, "expected ERROR")
-	require.Equal(t, wamp.ErrCanceled, rslt.Error)
+	require.Equal(t, wamp.ErrTimeout, rslt.Error)
 	require.NotZero(t, len(rslt.Arguments), "expected response argument")
 	s, _ := wamp.AsString(rslt.Arguments[0])
 	require.Equal(t, "call timeout", s, "Did not get error message from caller")

--- a/router/dealer_test.go
+++ b/router/dealer_test.go
@@ -263,6 +263,49 @@ func TestCancelOnCalleeGone(t *testing.T) {
 
 // ----- WAMP v.2 Testing -----
 
+func TestCallTimeoutOnRouter(t *testing.T) {
+	dealer, metaClient := newTestDealer(t)
+
+	callTimeout := 800
+
+	// Register a procedure.
+	callee := newTestPeer()
+	calleeSess := wamp.NewSession(callee, 0, nil, nil)
+	dealer.register(calleeSess,
+		&wamp.Register{Request: 123, Procedure: testProcedure})
+	rsp := <-callee.Recv()
+	_, ok := rsp.(*wamp.Registered)
+	require.True(t, ok, "did not receive REGISTERED response")
+
+	checkMetaReg(t, metaClient, calleeSess.ID)
+
+	caller := newTestPeer()
+	callerSession := wamp.NewSession(caller, 0, nil, nil)
+
+	// Test calling valid procedure
+	dealer.call(callerSession,
+		&wamp.Call{Request: 125, Options: wamp.Dict{wamp.OptTimeout: callTimeout}, Procedure: testProcedure})
+
+	// Test that callee received an INVOCATION message.
+	rsp = <-callee.Recv()
+	_, ok = rsp.(*wamp.Invocation)
+	require.True(t, ok, "expected INVOCATION")
+
+	select {
+	case <-time.After(time.Duration(callTimeout*2) * time.Millisecond):
+		require.FailNow(t, "caller not received error message")
+	case rsp = <-caller.Recv():
+	}
+
+	// Check that caller receives the ERROR message.
+	rslt, ok := rsp.(*wamp.Error)
+	require.True(t, ok, "expected ERROR")
+	require.Equal(t, wamp.ErrCanceled, rslt.Error)
+	require.NotZero(t, len(rslt.Arguments), "expected response argument")
+	s, _ := wamp.AsString(rslt.Arguments[0])
+	require.Equal(t, "call timeout", s, "Did not get error message from caller")
+}
+
 func TestCancelCallModeKill(t *testing.T) {
 	dealer, metaClient := newTestDealer(t)
 
@@ -866,17 +909,12 @@ func TestPatternBasedRegistration(t *testing.T) {
 }
 
 func TestRPCBlockedUnresponsiveCallee(t *testing.T) {
-	const (
-		rpcExecTime    = time.Second
-		timeoutMs      = 2000
-		shortTimeoutMs = 200
-	)
 	dealer, metaClient := newTestDealer(t)
 
 	// Register a procedure.
 	callee, rtr := transport.LinkedPeers()
 	calleeSess := wamp.NewSession(rtr, 0, nil, nil)
-	opts := wamp.Dict{wamp.OptTimeout: timeoutMs}
+	opts := wamp.Dict{}
 	dealer.register(calleeSess,
 		&wamp.Register{Request: 223, Procedure: testProcedure, Options: opts})
 	rsp := <-callee.Recv()

--- a/wamp/options.go
+++ b/wamp/options.go
@@ -22,6 +22,7 @@ const (
 	OptPPTCipher       = "ppt_cipher"
 	OptPPTKeyId        = "ppt_keyid"
 	OptSticky          = "sticky"
+	OptForwardTimeout  = "forward_timeout"
 
 	// Values for URI matching mode.
 	MatchExact    = "exact"

--- a/wamp/uris.go
+++ b/wamp/uris.go
@@ -86,6 +86,9 @@ const (
 	// A Dealer or Callee canceled a call previously issued.
 	ErrCanceled = URI("wamp.error.canceled")
 
+	// A Dealer canceled a call due to time out
+	ErrTimeout = URI("wamp.error.timeout")
+
 	// A Peer requested an interaction with an option that was disallowed by
 	// the Router.
 	ErrOptionNotAllowed = URI("wamp.error.option_not_allowed")


### PR DESCRIPTION
### Description, Motivation and Context

WAMP Spec  in the [Call Timeout section](https://wamp-proto.org/wamp_latest_ietf.html#name-call-timeouts) describes the `forward_timeout` property and how it should be used:

> If the Callee supports Call Timeouts, the Dealer MAY propagate the CALL.Options.timeout|integer option via the INVOCATION message and allow the Callee to handle the timeout logic. If the operation times out, the Callee MUST return an ERROR message with wamp.error.timeout as the reason URI.

> Callees wanting to handle the timeout logic MAY specify this intention via the REGISTER.Options.forward_timeout|boolean option. The Dealer, upon receiving a CALL with the timeout option set, checks if the matching RPC registration had the forward_timeout option set, then accordingly either forwards the timeout value or handles the timeout logic locally without forwarding the timeout value.

This PR introduces such option processing and by the way, fixes the timeout logic. Previously if the timeout was specified by the Caller - it was handled by the router and propagated to the Callee at the same time and only in case when Callee supports it (see snippet below):

```go
	timeout, _ := wamp.AsInt64(invk.options[wamp.OptTimeout])
	if timeout > 0 {
		// Check that callee supports call_timeout.
		if callee.HasFeature(wamp.RoleCallee, wamp.FeatureCallTimeout) {
			details[wamp.OptTimeout] = timeout
		} else {
			timeout = 0
		}
	}
```

This PR depends on https://github.com/gammazero/nexus/pull/307. After that is merged this one will be rebased to reflect only relevant changes.

### What kind of change does this PR introduce?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] Overall test coverage is not decreased.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
