### PR TITLE
websocketpeer: don't crash if Close() called multiple times

### DIFF
--- a/transport/websocketpeer.go
+++ b/transport/websocketpeer.go
@@ -234,6 +234,12 @@ func (w *websocketPeer) IsLocal() bool { return false }
 //
 // *** Do not call Send after calling Close. ***
 func (w *websocketPeer) Close() {
+	select {
+	case <-w.closed:
+		return
+	default:
+	}
+
 	// Tell sendHandler to exit and discard any queued messages.  Do not close
 	// wr channel in case there are incoming messages during close.
 	w.cancelSender()

--- a/transport/websocketpeer_test.go
+++ b/transport/websocketpeer_test.go
@@ -1,0 +1,41 @@
+package transport_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gammazero/nexus/v3/router"
+	"github.com/gammazero/nexus/v3/transport"
+	"github.com/gammazero/nexus/v3/transport/serialize"
+	"github.com/gammazero/nexus/v3/wamp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloseWebsocketPeer(t *testing.T) {
+	routerConfig := &router.Config{
+		RealmConfigs: []*router.RealmConfig{
+			{
+				URI: wamp.URI("nexus.test.realm"),
+			},
+		},
+	}
+	r, err := router.NewRouter(routerConfig, nil)
+	require.NoError(t, err)
+	defer r.Close()
+
+	const wsAddr = "127.0.0.1:8000"
+	closer, err := router.NewWebsocketServer(r).ListenAndServe(wsAddr)
+	require.NoError(t, err)
+	defer closer.Close()
+
+	client, err := transport.ConnectWebsocketPeer(
+		context.Background(), fmt.Sprintf("ws://%s/", wsAddr), serialize.JSON, nil, r.Logger(), nil)
+	require.NoError(t, err)
+
+	// Close the client connection.
+	client.Close()
+
+	// Try closing the client connection again. It should not cause an error.
+	client.Close()
+}

--- a/transport/websocketpeer_test.go
+++ b/transport/websocketpeer_test.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/gammazero/nexus/v3/router"
 	"github.com/gammazero/nexus/v3/transport"
 	"github.com/gammazero/nexus/v3/transport/serialize"
 	"github.com/gammazero/nexus/v3/wamp"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCloseWebsocketPeer(t *testing.T) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description, Motivation and Context
Refactor Close method in websocketPeer to handle duplicate close calls.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### What is the current behavior?
The router crashes on duplicate close call.

### What is the new behavior?
Duplicate close calls are handled.

### What kind of change does this PR introduce?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [ ] Overall test coverage is not decreased.
- [ ] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
