### PR TITLE
Fix router closes client in case of hello timeout

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -152,6 +152,7 @@ func (r *router) AttachClient(client wamp.Peer, transportDetails wamp.Dict) erro
 	// Receive HELLO message from the client.
 	msg, err := wamp.RecvTimeout(client, helloTimeout)
 	if err != nil {
+		client.Close()
 		return errors.New("did not receive HELLO: " + err.Error())
 	}
 	if r.debug {


### PR DESCRIPTION
Solves goroutine leak in case of timeout of HELLO message from client.

### Description, Motivation and Context
All other return statements with error in this function are called after method `sendAbort` that closes client. This PR adds close of client to last case that is missing. 

### What is the current behavior?
https://github.com/gammazero/nexus/issues/242

### What is the new behavior?
Client is closed after HELLO message timeout. This means that all goroutines of client end and memory can be collected.

### What kind of change does this PR introduce?
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] Overall test coverage is not decreased.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
