### PR TITLE
Dealer use session scoped IDs for callee

### DIFF
--- a/router/dealer.go
+++ b/router/dealer.go
@@ -703,15 +703,12 @@ func (d *dealer) syncCall(caller *wamp.Session, msg *wamp.Call) {
 			request: msg.Request,
 		}
 		d.calls[reqID] = caller
-		invocationID = d.idGen.Next()
 		invk = &invocation{
 			callID:     reqID,
 			callee:     callee,
 			inProgress: isInProgress,
 			options:    msg.Options,
 		}
-		d.invocations[invocationID] = invk
-		d.invocationByCall[reqID] = invocationID
 
 		// Let's check if callee supports this feature
 		// A Callee that supports progressive call invocations, but does not support call canceling,
@@ -812,6 +809,11 @@ func (d *dealer) syncCall(caller *wamp.Session, msg *wamp.Call) {
 			details[wamp.OptProcedure] = msg.Procedure
 		}
 
+		// Only now that we know we're going to send the invocation can we
+		// generate the invocationID
+		invocationID = callee.IdGen.Next()
+		d.invocations[invocationID] = invk
+		d.invocationByCall[reqID] = invocationID
 	} else {
 		// It is an ongoing progressive call (not first one)
 		invk = d.invocations[storedInvocationID]

--- a/router/dealer_test.go
+++ b/router/dealer_test.go
@@ -173,6 +173,105 @@ func TestBasicCall(t *testing.T) {
 	require.Equal(t, wamp.ID(126), errMsg.Request, "wrong request ID in ERROR, should match call ID")
 }
 
+// Ensure INVOCATION.Request IDs are incremented by 1 and scoped to the
+// Callee's session.
+func TestInvocationSessionSequentialIDs(t *testing.T) {
+	dealer, _ := newTestDealer(t)
+	dealer.debug = true
+
+	// Set up 2 Callees with 2 unique registered procedure names
+	const numCallee = 2
+	const numProcNames = 2
+	var procNames [numCallee][numProcNames]wamp.URI
+	var callee [numCallee]*testPeer
+	var calleeSess [numCallee]*wamp.Session
+
+	routerScopeID := 1
+	for i := 0; i < numCallee; i++ {
+		callee[i] = newTestPeer()
+		calleeSess[i] = wamp.NewSession(callee[i], wamp.ID(9990+i), nil, nil)
+
+		for n := 0; n < numProcNames; n++ {
+			procNames[i][n] = wamp.URI(fmt.Sprintf("nexus.test.callee%d.proc%d", i, n))
+			dealer.register(calleeSess[i],
+				&wamp.Register{
+					Request:   wamp.ID(n),
+					Procedure: procNames[i][n],
+				})
+
+			var rsp wamp.Message
+			select {
+			case rsp = <-callee[i].Recv():
+			case <-time.After(time.Millisecond):
+				require.FailNowf(t, "timed out waiting for response", "callee[%d]", i)
+			}
+			switch rsp.(type) {
+			case *wamp.Registered:
+				// Tests that Dealer is using router scoped IDs for proc reg
+				require.Equal(t, wamp.ID(routerScopeID),
+					rsp.(*wamp.Registered).Registration)
+				routerScopeID++
+			case *wamp.Error:
+				require.FailNowf(t, "error registering procedure",
+					"callee[%d] err=%v", i, rsp.(*wamp.Error))
+			default:
+				require.FailNowf(t, "did not receive REGISTERED response",
+					"callee[%d] got=%v", i, rsp.MessageType())
+
+			}
+		}
+	}
+
+	// Create a Callers to test invocation of each procedure
+	const numCallers = 2
+	var caller [numCallers]*testPeer
+	var callerSess [numCallers]*wamp.Session
+	for i := 0; i < numCallers; i++ {
+		caller[i] = newTestPeer()
+		callerSess[i] = wamp.NewSession(caller[i], wamp.ID(2240+i), nil, nil)
+	}
+
+	// Call procName and ensure callee got expectedID for INVOCATION.request
+	callAndCheckInvocationRequestID := func(callerIdx int, calleeSess *wamp.Session, procName wamp.URI, expectedID int) {
+		fmt.Println("calling", procName)
+		dealer.call(
+			callerSess[callerIdx],
+			&wamp.Call{Request: callerSess[callerIdx].IdGen.Next(), Procedure: procName})
+
+		rsp, err := wamp.RecvTimeout(calleeSess, time.Second)
+		require.Nil(t, err)
+		if _, ok := rsp.(*wamp.Error); ok {
+			require.FailNow(t, "unexpected error from callee", rsp.(*wamp.Error))
+		}
+
+		inv, ok := rsp.(*wamp.Invocation)
+		require.True(t, ok, "expected INVOCATION; Got: ", rsp.MessageType().String())
+		require.Equalf(t, wamp.ID(expectedID), inv.Request,
+			"invocation request ID should be %d", expectedID)
+	}
+
+	// Caller 0 invoke Callee 0 and 1 with both procedures
+	callAndCheckInvocationRequestID(0, calleeSess[1], procNames[1][0], 1)
+	callAndCheckInvocationRequestID(0, calleeSess[1], procNames[1][1], 2)
+	callAndCheckInvocationRequestID(0, calleeSess[0], procNames[0][0], 1)
+	callAndCheckInvocationRequestID(0, calleeSess[0], procNames[0][1], 2)
+
+	callAndCheckInvocationRequestID(0, calleeSess[1], procNames[1][1], 3)
+	callAndCheckInvocationRequestID(0, calleeSess[0], procNames[0][0], 3)
+
+	// Caller 1 invoke Callee 0 with both procedures
+	// Because it is the same Callee (even with different Caller) the IDs
+	// continue to increment
+	callAndCheckInvocationRequestID(1, calleeSess[0], procNames[0][1], 4)
+	callAndCheckInvocationRequestID(1, calleeSess[0], procNames[0][0], 5)
+
+	// Weave Callers on Callee 1
+	callAndCheckInvocationRequestID(1, calleeSess[1], procNames[1][1], 4)
+	callAndCheckInvocationRequestID(0, calleeSess[1], procNames[1][0], 5)
+	callAndCheckInvocationRequestID(1, calleeSess[1], procNames[1][0], 6)
+	callAndCheckInvocationRequestID(0, calleeSess[1], procNames[1][1], 7)
+}
+
 func TestRemovePeer(t *testing.T) {
 	dealer, metaClient := newTestDealer(t)
 

--- a/wamp/idgen.go
+++ b/wamp/idgen.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const maxID int64 = 1 << 53
+const MaxID uint64 = 1 << 53
 
 func init() {
 	rand.Seed(time.Now().UnixNano())
@@ -14,7 +14,7 @@ func init() {
 
 // NewID generates a random WAMP ID.
 func GlobalID() ID {
-	return ID(rand.Int63n(maxID)) //nolint:gosec
+	return ID(rand.Int63n(int64(MaxID))) //nolint:gosec
 }
 
 // IDGen is generator for WAMP request IDs.  Create with new(IDGen).
@@ -29,13 +29,13 @@ func GlobalID() ID {
 //
 // See https://github.com/wamp-proto/wamp-proto/blob/master/spec/basic.md#ids
 type IDGen struct {
-	next int64
+	next uint64
 }
 
 // Next returns next ID.
 func (g *IDGen) Next() ID {
 	g.next++
-	if g.next > maxID {
+	if g.next > MaxID {
 		g.next = 1
 	}
 	return ID(g.next)

--- a/wamp/idgen_test.go
+++ b/wamp/idgen_test.go
@@ -26,7 +26,7 @@ func TestIDGen(t *testing.T) {
 	require.Equal(t, ID(2), id2, errMsg)
 	require.Equal(t, ID(3), id3, errMsg)
 
-	idgen.next = int64(1) << 53
+	idgen.next = uint64(1) << 53
 	id1 = idgen.Next()
 	require.Equal(t, ID(1), id1, "Sequential IDs should wrap at 1 << 53")
 }

--- a/wamp/session.go
+++ b/wamp/session.go
@@ -5,6 +5,11 @@ import (
 	"sync"
 )
 
+// IDs that are at most deltaID away from lastRecvID are considered new
+const deltaID = ID(500)
+const rollLowID = deltaID / 2
+const rollHighID = ID(MaxID) - rollLowID
+
 // Session is an active WAMP session.  It associates a session ID and details
 // with a connected Peer, which is the remote side of the session.  So, if the
 // session owned by the router, then the Peer is the connected client.
@@ -15,6 +20,10 @@ type Session struct {
 	ID ID
 	// Details about session.
 	Details Dict
+	IdGen   *SyncIDGen
+	// Greatest value of Dealer's end of Session Scope ID
+	// Use IsNewRecvID() and UpdateLastRecvID() for comparison/update.
+	lastRecvID ID
 
 	// Roles and features supported by peer.
 	roles map[string]map[string]struct{}
@@ -36,6 +45,7 @@ func NewSession(peer Peer, id ID, details Dict, greetDetails Dict) *Session {
 		Peer:    peer,
 		ID:      id,
 		Details: details,
+		IdGen:   new(SyncIDGen),
 	}
 	s.setRoles(greetDetails)
 	return s
@@ -160,4 +170,54 @@ func (s *Session) setRoles(details Dict) {
 		roleMap[role] = featMap
 	}
 	s.roles = roleMap
+}
+
+// UpdateLastRecvID updates the Session's lastRecvID with IDs coming from the
+// other end. Returns true if this is a new ID.
+// This is our only way to track the session-based request IDs to determine if
+// we're responding to a new request.
+func (s *Session) UpdateLastRecvID(id ID) bool {
+	s.Lock()
+	defer s.Unlock()
+	return s.UpdateLastRecvIDCallerHasSessionLock(id)
+}
+
+// UpdateLastRecvIDCallerHasSessionLock works just like UpdateLastRecvID if you
+// already have a session lock.
+func (s *Session) UpdateLastRecvIDCallerHasSessionLock(id ID) bool {
+	if s.IsNewRecvID(id) {
+		s.lastRecvID = id
+		return true
+	}
+	return false
+}
+
+// IsNewRecvID returns true if the ID is considered new.
+// It is recommended to only call this function when you have the Session.Lock.
+func (s *Session) IsNewRecvID(id ID) bool {
+	// It would be really nice if we could trust that when lastRecvID is
+	// MaxID the next ID would be 1, but it's completely possible for a
+	// Dealer to skip IDs if there were internal errors or if it incorrectly
+	// uses Dealer scoped IDs instead of Session scoped (*cough* Nexus).
+	// In order to maximize compatability, we allow ID rollover/wraparound
+	// when we're close to the max ID value (rollHighID) and the new ID is close
+	// to 1 (rollLowID).
+
+	last := s.lastRecvID
+
+	// Equal
+	if id == last {
+		return false
+	}
+	// Rollover / wraparound
+	if last > rollHighID && id < rollLowID {
+		return true
+	}
+	// Can only advance at most deltaID
+	// This is specifically to prevent jumping right back into the
+	// rollHighID range after a rollover/wraparound, but't's  it's good genearl
+	if id > last && (id-last) < deltaID {
+		return true
+	}
+	return false
 }

--- a/wamp/session_test.go
+++ b/wamp/session_test.go
@@ -1,0 +1,41 @@
+package wamp
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestIsNewRecvIDBounds(t *testing.T) {
+	testCases := [...]struct {
+		last     ID
+		id       ID
+		expected bool
+	}{
+		{last: 0, id: 1, expected: true},
+		{last: 1, id: 0, expected: false},
+		{last: 1, id: 1, expected: false},
+		{last: ID(MaxID), id: 1, expected: true},      // rollover
+		{last: rollHighID + 1, id: 1, expected: true}, // rollover w/ fudge
+		{last: rollHighID, id: 1, expected: false},    // not yet a rollover
+		// valid for rollover but new value is too far out of bounds
+		{last: rollHighID + 1, id: rollLowID, expected: false},
+		{last: rollHighID + 1, id: rollLowID - 1, expected: true},
+		// id is technically out of bounds but that's OK
+		{last: ID(MaxID), id: ID(MaxID + 5), expected: true},
+		// Can't jump more than deltaID (prevents flip-fop after rollover)
+		{last: 1, id: rollHighID + 1, expected: false},
+		{last: 100, id: 100 + deltaID, expected: false},
+		{last: 100, id: 100 + deltaID - 1, expected: true},
+	}
+
+	s := Session{lastRecvID: 0}
+	for i, tc := range testCases {
+		tc := tc
+		name := fmt.Sprintf("%02d_%d-%d-%v", i, tc.last, tc.id, tc.expected)
+		t.Run(name, func(t *testing.T) {
+			s.lastRecvID = tc.last
+			require.Equal(t, tc.expected, s.IsNewRecvID(tc.id))
+		})
+	}
+}


### PR DESCRIPTION
### Description, Motivation and Context

Dealers now use [session-scoped IDs](https://wamp-proto.org/wamp_latest_ietf.html#section-2.1.2-11) for `INVOCATION.Request`

### What is the current behavior?

Currently, Dealers use Dealer-scoped IDs which means different Callees would receive non-sequential `INVOCATION.Request` IDs.

### What is the new behavior?

IDs for `INVOCATION.Request` are now scoped to the Callee's session.

### What kind of change does this PR introduce?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] Overall test coverage is not decreased.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
