### PR TITLE
fix msgpack decoding when message type encoded as uint64

### DIFF
--- a/transport/serialize/msgpackserializer.go
+++ b/transport/serialize/msgpackserializer.go
@@ -2,6 +2,7 @@ package serialize
 
 import (
 	"errors"
+	"math"
 	"reflect"
 
 	"github.com/ugorji/go/codec"
@@ -67,7 +68,11 @@ func (s *MessagePackSerializer) Deserialize(data []byte) (wamp.Message, error) {
 
 	typ, ok := v[0].(int64)
 	if !ok {
-		return nil, errors.New("unsupported message format")
+		utyp, ok := v[0].(uint64)
+		if !ok || utyp > math.MaxInt {
+			return nil, errors.New("unsupported message format")
+		}
+		typ = int64(utyp)
 	}
 	return listToMsg(wamp.MessageType(typ), v)
 }


### PR DESCRIPTION

Replaces #323
Thank you for fix @muzzammilshahid 

<!--- Provide a general summary of your changes in the Title above -->

### Description, Motivation and Context
(Describe your changes in detail)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allow msgpack deserialization to work when decoded type is uint64, which cannot be directly asserted to int64.

### What is the current behavior?
(You can also link to an open issue here)
Deserialization fails when decoded type is uint64

### What is the new behavior?
(if this is a feature change)
msgpack deserialization to work when decoded type is int64 or uint64

### What kind of change does this PR introduce?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Enhancement (improve existing code or documentation without affecting behavior)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] Overall test coverage is not decreased.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
