### PR TITLE
fix: router closes client in case of no hello from client

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -151,6 +151,7 @@ func (r *router) AttachClient(client wamp.Peer, transportDetails wamp.Dict) erro
 	// Receive HELLO message from the client.
 	msg, err := wamp.RecvTimeout(client, helloTimeout)
 	if err != nil {
+		client.Close()
 		return errors.New("did not receive HELLO: " + err.Error())
 	}
 	if r.debug {


### PR DESCRIPTION
Replaces #318
Thank you @AdamLutka for this fix

Fixes goroutine leak in case of timeout of HELLO message from client.

Addresses #242

<!--- Provide a general summary of your changes in the Title above -->

### Description, Motivation and Context
(Describe your changes in detail)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
All other return statements with error in this function are called after method sendAbort that closes client. This PR adds close of client to last case that is missing.

### What is the current behavior?
(You can also link to an open issue here)
#242

### What is the new behavior?
(if this is a feature change)
Client is closed after HELLO message timeout. This means that all goroutines of client end and memory can be collected.

### What kind of change does this PR introduce?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Enhancement (improve existing code or documentation without affecting behavior)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] Overall test coverage is not decreased.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
