### PR TITLE
[#343] Copy maps to avoid concurrent access during serialization

### DIFF
--- a/router/broker.go
+++ b/router/broker.go
@@ -3,7 +3,6 @@ package router
 import (
 	"fmt"
 	"maps"
-	"slices"
 	"time"
 
 	"github.com/gammazero/deque"

--- a/router/broker.go
+++ b/router/broker.go
@@ -745,16 +745,33 @@ func (b *broker) trySend(sess *wamp.Session, msg wamp.Message) {
 }
 
 func prepareEvent(pub *wamp.Session, msg *wamp.Publish, pubID wamp.ID, sub *subscription, sendTopic, disclose bool, eventDetails wamp.Dict, subscriber *wamp.Session) *wamp.Event { //nolint:lll
-	details := eventDetails
-	if details == nil {
+	// Make defensive copies of all maps to prevent concurrent map iteration and write issues.
+	// These maps may be accessed concurrently by multiple goroutines during serialization.
+	var details wamp.Dict
+	if eventDetails != nil {
+		details = make(map[string]any, len(eventDetails))
+		maps.Copy(details, eventDetails)
+	} else {
 		details = wamp.Dict{}
+	}
+
+	var args wamp.List
+	if msg.Arguments != nil {
+		args = make([]any, len(msg.Arguments))
+		copy(args, msg.Arguments)
+	}
+
+	var argsKw wamp.Dict
+	if msg.ArgumentsKw != nil {
+		argsKw = make(map[string]any, len(msg.ArgumentsKw))
+		maps.Copy(argsKw, msg.ArgumentsKw)
 	}
 
 	event := &wamp.Event{
 		Publication:  pubID,
 		Subscription: sub.id,
-		Arguments:    msg.Arguments,
-		ArgumentsKw:  msg.ArgumentsKw,
+		Arguments:    args,
+		ArgumentsKw:  argsKw,
 		Details:      details,
 	}
 	// If a subscription was established with a pattern-based matching policy,
@@ -769,25 +786,6 @@ func prepareEvent(pub *wamp.Session, msg *wamp.Publish, pubID wamp.ID, sub *subs
 
 	// TODO: Handle publication trust levels.
 
-	if subscriber != nil && subscriber.IsLocal() {
-		// The local handler may be lousy and may try to modify either of those
-		// fields, make sure that each event carries a copy of the respective
-		// structure, even if it's empty.
-		if event.Details != nil {
-			options := make(map[string]any, len(event.Details))
-			maps.Copy(options, event.Details)
-			event.Details = options
-		}
-		if msg.Arguments != nil {
-			event.Arguments = make([]any, len(msg.Arguments))
-			copy(event.Arguments, msg.Arguments)
-		}
-		if msg.ArgumentsKw != nil {
-			argsKw := make(map[string]any, len(msg.ArgumentsKw))
-			maps.Copy(argsKw, msg.ArgumentsKw)
-			event.ArgumentsKw = argsKw
-		}
-	}
 	return event
 }
 

--- a/router/dealer.go
+++ b/router/dealer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math/rand"
 	"strings"
 	"time"
@@ -861,12 +862,24 @@ func (d *dealer) syncCall(caller *wamp.Session, msg *wamp.Call) {
 
 	// Send INVOCATION to the endpoint that has registered the requested
 	// procedure.
+	// Make defensive copies to prevent concurrent map access during serialization.
+	var args wamp.List
+	if msg.Arguments != nil {
+		args = make([]any, len(msg.Arguments))
+		copy(args, msg.Arguments)
+	}
+	var argsKw wamp.Dict
+	if msg.ArgumentsKw != nil {
+		argsKw = make(map[string]any, len(msg.ArgumentsKw))
+		maps.Copy(argsKw, msg.ArgumentsKw)
+	}
+
 	invMsg := &wamp.Invocation{
 		Request:      invocationID,
 		Registration: reg.id,
 		Details:      details,
-		Arguments:    msg.Arguments,
-		ArgumentsKw:  msg.ArgumentsKw,
+		Arguments:    args,
+		ArgumentsKw:  argsKw,
 	}
 	select {
 	case callee.Send() <- invMsg:
@@ -1143,11 +1156,22 @@ func (d *dealer) syncYield(callee *wamp.Session, msg *wamp.Yield, progress, canR
 	// callee wait and retry sending this message again. The caller may be
 	// blocked when the callee is generating progressive responses faster than
 	// the caller can handle them.
+	var args wamp.List
+	if msg.Arguments != nil {
+		args = make([]any, len(msg.Arguments))
+		copy(args, msg.Arguments)
+	}
+	var argsKw wamp.Dict
+	if msg.ArgumentsKw != nil {
+		argsKw = make(map[string]any, len(msg.ArgumentsKw))
+		maps.Copy(argsKw, msg.ArgumentsKw)
+	}
+
 	res := &wamp.Result{
 		Request:     callID.request,
 		Details:     details,
-		Arguments:   msg.Arguments,
-		ArgumentsKw: msg.ArgumentsKw,
+		Arguments:   args,
+		ArgumentsKw: argsKw,
 	}
 	select {
 	case caller.Send() <- res:


### PR DESCRIPTION
### Description, Motivation and Context

Fixes concurrent access panic described in #343 for websocket clients

### What is the current behavior?

`prepareEvent` didn't copy details / args / kwargs for websocket clients


### What is the new behavior?

details / args / kwargs are now copied at the top of `prepareEvent`


### What kind of change does this PR introduce?
- [ ] Enhancement (improve existing code or documentation without affecting behavior)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] Overall test coverage is not decreased.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

---

Worth saying, I did spend some time trying to come up with a stress test to trigger this issue, but couldn't make it fall over on the old implementation, but trying this change with our real app does appear to fix the issue that we were having.
I know it's not satisfying to not have a minimal repro.

I'm also not a go developer, so there may be more elegant ways of doing this, would welcome the feedback.