### PR TITLE
ci: add coverage badge generator and make targets

### DIFF
--- a/.github/workflows/main-golint.yml
+++ b/.github/workflows/main-golint.yml
@@ -85,3 +85,14 @@ jobs:
 
       - name: Check build of nexusd
         run: make service
+
+      - name: Run coverage and refresh README badge
+        if: matrix.os == 'ubuntu-latest'
+        run: make coverage
+
+      - name: Report coverage drift in README badge
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          if ! git diff --exit-code -- README.md; then
+            echo "::warning::README.md coverage badge differs from committed version. Run 'make coverage' locally and commit the result if you want the badge refreshed."
+          fi

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SERVICE_DIR = nexusd
 
-.PHONY: all vet test service clean install uninstall
+.PHONY: all vet test service clean install uninstall test-coverage coverage-badge coverage
 
 all: vet test service
 
@@ -26,6 +26,34 @@ benchmark:
 	go test ./test -run=XXX -bench=. -scheme=tcp
 	go test ./test -run=XXX -bench=. -scheme=tcps
 	go test ./test -run=XXX -bench=. -scheme=ws -compress
+
+# Run the full suite once with coverage instrumentation. The transport-matrix
+# variants in `test` are not re-run here — they exercise transport edge cases,
+# not different code paths in the router/wamp/client packages we measure.
+test-coverage:
+	go test -race -coverprofile=coverage.out -covermode=atomic ./...
+	go tool cover -func=coverage.out | tail -1 | awk '{print $$3}' > coverage.txt
+	@printf 'total coverage: %s\n' "$$(cat coverage.txt)"
+
+# Rewrite the README coverage badge line to a shields.io URL with the
+# current percentage and a color picked from the same thresholds shields.io
+# uses for its built-in coverage badges. shields.io renders the badge on
+# the fly, so no SVG file is committed. Idempotent: same percentage → no
+# diff. Cross-platform sed -i (works under BSD and GNU sed).
+coverage-badge: test-coverage
+	@PCT=$$(tr -d '%' < coverage.txt); \
+	COLOR=$$(awk -v p="$$PCT" 'BEGIN { \
+		if (p<50) print "red"; \
+		else if (p<70) print "orange"; \
+		else if (p<80) print "yellow"; \
+		else if (p<90) print "yellowgreen"; \
+		else print "brightgreen" }'); \
+	sed -i.bak -E "s|coverage-[0-9.]+%25-[a-z]+|coverage-$${PCT}%25-$${COLOR}|" README.md; \
+	rm -f README.md.bak; \
+	printf 'coverage badge: %s%% (%s)\n' "$$PCT" "$$COLOR"
+
+# Top-level: tests with coverage + badge regen. Run before pushing.
+coverage: coverage-badge
 
 service: $(SERVICE_DIR)/nexusd
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 # WAMP v2 router library, client library and router service
 
-[![Build Status](https://travis-ci.org/gammazero/nexus.svg)](https://travis-ci.org/gammazero/nexus)
+[![Main CI](https://github.com/gammazero/nexus/actions/workflows/main-golint.yml/badge.svg)](https://github.com/gammazero/nexus/actions/workflows/main-golint.yml)
+[![Coverage](https://img.shields.io/badge/coverage-56.1%25-orange)](https://github.com/gammazero/nexus/actions/workflows/main-golint.yml)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![GoDoc](https://godoc.org/github.com/gammazero/nexus?status.svg)](https://godoc.org/github.com/gammazero/nexus)
 


### PR DESCRIPTION
Replaces the dead Travis badge in README.md with a GitHub Actions CI badge and a shields.io coverage badge whose percentage is regenerated in place by `make coverage`.

- `make test-coverage` runs `go test -race -coverprofile` once over the whole module and writes the total percentage to coverage.txt. The transport-matrix variants in `make test` are intentionally not re-run here since they exercise transport edge cases, not different code paths in the router/wamp/client packages we measure.
- `make coverage-badge` (depends on test-coverage) reads coverage.txt, picks a shields.io-compatible color from the same thresholds shields uses for its built-in coverage badges (red/orange/yellow/yellowgreen/ brightgreen at 50/70/80/90), and rewrites the Coverage badge URL in README.md in place via cross-platform sed. shields.io renders the badge on the fly so no SVG artifact is committed.
- `make coverage` is a convenience alias.

CI runs `make coverage` on ubuntu-latest and warns (does not fail) if the badge in README.md drifted, so PRs with stale badges surface in the workflow logs without blocking merge.

Re-running `make coverage` against the same percentage produces no diff (deterministic output).

<!--- Provide a general summary of your changes in the Title above -->

### Description, Motivation and Context

We want to extend and harden the nexus for our usage patterns. We would like to do this in an upstream friendly way.
First on our list is to extend the testing framework to cover more tests and to provide a WAMP-spec harness.
This is a first PR with just a code coverage badge and tooling. 

The goal is to just make test coverage more transparent and coverage more prominent.

### What kind of change does this PR introduce?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Enhancement (improve existing code or documentation without affecting behavior)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] Overall test coverage is not decreased.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
